### PR TITLE
Fix not switch workstation from panel button

### DIFF
--- a/src/services/window_manager_service/sway/sway_client.c
+++ b/src/services/window_manager_service/sway/sway_client.c
@@ -1,6 +1,7 @@
 #include "sway_client.h"
 
 #include <adwaita.h>
+#include <ctype.h>
 #include <asm-generic/errno.h>
 #include <errno.h>
 #include <glob.h>
@@ -453,6 +454,11 @@ int sway_client_ipc_focus_workspace(int socket_fd, gchar *name) {
     if (!name) {
         return -1;
     }
+
+    if (isdigit(name[0])) {
+        cmd = "workspace number ";
+    }
+
     msg.size = strlen(cmd) + strlen(name) + 1;
     msg.payload = g_malloc0(msg.size);
 


### PR DESCRIPTION
I use an autoname script for my workspaces, and the buttons on the panel would not switch correctly, they would create a new workspace, but waybar does work correctly.

I took inspiration from the waybar code, and created this patch which now correctly switches workstations for me both when I am running the autoname script, and without it using standard workspace names.