### PR TITLE
fix(Makefile): add to existing flags instead of overwriting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ DEPS := libadwaita-1 \
 		wayland-protocols \
 		gio-unix-2.0 \
 		gtk4-layer-shell-0
-CFLAGS := $(shell pkg-config --cflags $(DEPS)) -g3 -Wall
+CFLAGS += $(shell pkg-config --cflags $(DEPS)) -g3 -Wall
 # order is important here, if libwayland is linked before gtk4 layer shell
 # bad things happen.
-LIBS := "-lm"
+LIBS := $(LDFLAGS) "-lm"
 LIBS += $(shell pkg-config --libs $(DEPS))
 SOURCES := $(shell find src/ -type f -name *.c)
 OBJS := $(patsubst %.c, %.o, $(SOURCES))

--- a/way-sh/Makefile
+++ b/way-sh/Makefile
@@ -1,11 +1,11 @@
 CC = gcc
-CFLAGS = -g3 -Wall
+CFLAGS += -g3 -Wall
 SOURCES = $(shell find -type f -regex ".*\.c")
 OBJS = $(subst .c,.o,$(SOURCES))
 OBJS += ../lib/cmd_tree/cmd_tree.o
 
 way-sh: $(OBJS)
-	$(CC) $(CFLAGS) -o way-sh $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o way-sh $(OBJS)
 
 clean:
 	rm -rf way-sh


### PR DESCRIPTION
Some build environments set LDFLAGS and CFLAGS - the build system should
respect those and add to them.

(I did not rename then `LIBS` to `LDFLAGS`, but that would maybe also be an option)