### PR TITLE
logind: look up session for our PID instead of guessing

### DIFF
--- a/src/services/logind_service/logind_service.c
+++ b/src/services/logind_service/logind_service.c
@@ -76,6 +76,10 @@ static void logind_service_session_dbus_connect(LogindService *self) {
         gchar *obj_path;
         g_variant_get(session, "(susso)", &id, &sess_uid, &seat, &display,
                       &obj_path);
+
+        if (!seat)
+            continue;
+
         if (sess_uid == uid) {
             session_obj_path = strdup(obj_path);
             session_id = strdup(id);


### PR DESCRIPTION
this fixes brightness control on my machine, as I have two sessions: one that greetd opens on seat0, and one that systemd opens with no seat; we were binding to the latter, and failing to set brightness because there was no seat.