### PR TITLE
allow configuring clock format via gsettings

### DIFF
--- a/data/org.ldelossa.way-shell.gschema.xml
+++ b/data/org.ldelossa.way-shell.gschema.xml
@@ -139,4 +139,19 @@
         </key>
     </schema>
 
+    <!--panel related settings-->
+    <schema path="/org/ldelossa/way-shell/panel/" id="org.ldelossa.way-shell.panel">
+        <key name="clock-format" type="s">
+            <default>"%b %d %I:%M"</default>
+            <summary>The format to display the current time in on the panel.</summary>
+            <description>
+            This is passed as the `format` argument to g_date_time_format when rendering the clock
+            in the panel.
+            Note that the clock only ticks every minute, so precise specifiers such as %S are
+            useless.
+            Way-Shell must be restarted for changes to take effect.
+            </description>
+        </key>
+    </schema>
+
 </schemalist>


### PR DESCRIPTION
I prefer to have a 24-hour clock, and this feels like a reasonable way to allow that.

There seemed to be no destructor for the panel clock object, so atm the format string never gets freed, but since it doesn't change for the lifetime of the clock (and I suppose there is only one clock per way-shell process?) maybe that doesn't matter.

---

we just store the g_date_time_format argument straight in gsettings,
so users can customise it via the gsettings cli. note that for simplicity
we don't connect any signal handlers so way-shell must be restarted on
change; hopefully nobody wants to hotswap their clock format.