### PR TITLE
Window manager abstraction

### DIFF
--- a/data/org.ldelossa.way-shell.gschema.xml
+++ b/data/org.ldelossa.way-shell.gschema.xml
@@ -65,6 +65,16 @@
 
     <!--window manager related settings-->
     <schema path="/org/ldelossa/way-shell/window-manager/" id="org.ldelossa.way-shell.window-manager">
+        <key name="backend" type="s">
+            <default>"sway"</default>
+            <summary>The window manager backend to use (default: sway)</summary>
+            <description>
+			Instructs Way-Shell which window manager to use.
+			Currently supported options are "sway".
+
+			Changing this setting requires a restart to take effect.
+            </description>
+        </key>
         <key name="sort-workspaces-alphabetical" type="b">
             <default>true</default>
             <summary>Sort workpaces alphabetically</summary>

--- a/src/activities/activities.c
+++ b/src/activities/activities.c
@@ -5,8 +5,6 @@
 #include <gio/gio.h>
 #include <gtk4-layer-shell/gtk4-layer-shell.h>
 
-#include "../services/window_manager_service/sway/window_manager_service_sway.h"
-#include "../services/window_manager_service/window_manager_service.h"
 #include "./activities_app_widget.h"
 #include "gtk/gtk.h"
 #include "gtk/gtkrevealer.h"
@@ -308,16 +306,6 @@ static void on_search_entry_activate(GtkSearchEntry *entry, Activities *self) {
 
     // simulate click
     activities_app_widget_simulate_click(app_widget);
-}
-
-static void on_workspace_button_clicked(GtkButton *button, Activities *self) {
-    g_debug("activities.c:on_workspace_button_clicked: called");
-
-    WMServiceSway *sway = wm_service_sway_get_global();
-    WMWorkspace *ws = g_object_get_data(G_OBJECT(button), "workspace");
-    wm_service_sway_focus_workspace(sway, ws);
-
-    activities_hide(self);
 }
 
 static void activities_init_layout(Activities *self) {

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <adwaita.h>
 
+#include "../gresources.h"
 #include "./activities/activities.h"
 #include "./app_switcher/app_switcher.h"
 #include "./dialog_overlay/dialog_overlay.h"
@@ -19,10 +20,9 @@
 #include "./services/theme_service.h"
 #include "./services/upower_service.h"
 #include "./services/wayland_service/wayland_service.h"
-#include "./services/window_manager_service/sway/window_manager_service_sway.h"
+#include "./services/window_manager_service/window_manager_service.h"
 #include "./services/wireplumber_service.h"
 #include "./workspace_switcher/workspace_switcher.h"
-#include "../gresources.h"
 #include "panel/panel_mediator.h"
 #include "panel/quick_settings/quick_settings.h"
 
@@ -82,8 +82,9 @@ static void activate(AdwApplication *app, gpointer user_data) {
             "service.");
     }
 
-    if (wm_service_sway_global_init() != 0) {
-        g_error("main.c: activate(): failed to initialize sway service.");
+    if (window_manager_service_init() != 0) {
+        g_error(
+            "main.c: activate(): failed to initialize window manager service.");
     }
 
     if (notifications_service_global_init() != 0) {
@@ -145,7 +146,6 @@ static void activate(AdwApplication *app, gpointer user_data) {
 
     panel_activate(app, user_data);
     g_debug("main.c: activate(): panel subsystems activated");
-
 
     // Subsystem mediator connections //
 

--- a/src/services/window_manager_service/sway/window_manager_service_sway.c
+++ b/src/services/window_manager_service/sway/window_manager_service_sway.c
@@ -7,8 +7,6 @@
 #include "ipc.h"
 #include "sway_client.h"
 
-static WMServiceSway *global = NULL;
-
 enum signals { workspaces_changed, outputs_changed, signals_n };
 
 struct _WMServiceSway {
@@ -141,7 +139,7 @@ static void handle_ipc_event_workspaces(WMServiceSway *self,
     if (event->type == WMWORKSPACE_EVENT_URGENT &&
         g_settings_get_boolean(self->settings, "focus-urgent-workspace")) {
         // switch to workspace
-        wm_service_sway_focus_workspace(self, &event->workspace);
+        sway_client_ipc_focus_workspace(self->socket_fd, &event->workspace);
     }
 
     if (event->type == WMWORKSPACE_EVENT_FOCUSED) {
@@ -284,28 +282,9 @@ static void wm_service_sway_init(WMServiceSway *self) {
                      G_CALLBACK(on_sort_alphabetical_changed), self);
 };
 
-// Initializes the sway wm service.
-int wm_service_sway_global_init(void) {
-    g_debug(
-        "window_manager_service_sway.c:wm_service_sway_global_init() "
-        "initializing global service.");
+GPtrArray *wm_service_sway_get_workspaces(WindowManager *wm) {
+    WMServiceSway *self = wm->private;
 
-    global = g_object_new(WM_SERVICE_SWAY_TYPE, NULL);
-
-    // subscribe to desired events
-    sway_client_ipc_subscribe_req(
-        global->socket_fd, (int[]){IPC_EVENT_WORKSPACE, IPC_EVENT_OUTPUT}, 2);
-
-    // get initial listing of workspaces
-    sway_client_ipc_get_workspaces_req(global->socket_fd);
-
-    // get initial listing of outputs
-    sway_client_ipc_get_outputs_req(global->socket_fd);
-
-    return 0;
-};
-
-GPtrArray *wm_service_sway_get_workspaces(WMServiceSway *self) {
     if (!self->workspaces) {
         g_warning(
             "window_manager_service_sway.c:wm_service_sway_get_workspaces() "
@@ -316,7 +295,9 @@ GPtrArray *wm_service_sway_get_workspaces(WMServiceSway *self) {
     return g_ptr_array_ref(self->workspaces);
 }
 
-GPtrArray *wm_service_sway_get_outputs(WMServiceSway *self) {
+GPtrArray *wm_service_sway_get_outputs(WindowManager *wm) {
+    WMServiceSway *self = wm->private;
+
     if (!self->outputs) {
         g_warning(
             "window_manager_service_sway.c:wm_service_sway_get_outputs() "
@@ -327,7 +308,9 @@ GPtrArray *wm_service_sway_get_outputs(WMServiceSway *self) {
     return g_ptr_array_ref(self->outputs);
 }
 
-int wm_service_sway_focus_workspace(WMServiceSway *self, WMWorkspace *ws) {
+int wm_service_sway_focus_workspace(WindowManager *wm, WMWorkspace *ws) {
+    WMServiceSway *self = wm->private;
+
     if (!self->workspaces) {
         g_warning(
             "window_manager_service_sway.c:wm_service_sway_focus_workspace() "
@@ -337,7 +320,9 @@ int wm_service_sway_focus_workspace(WMServiceSway *self, WMWorkspace *ws) {
     return sway_client_ipc_focus_workspace(self->socket_fd, ws);
 }
 
-int wm_service_sway_current_ws_to_output(WMServiceSway *self, WMOutput *o) {
+int wm_service_sway_current_ws_to_output(WindowManager *wm, WMOutput *o) {
+    WMServiceSway *self = wm->private;
+
     if (!o) {
         g_warning(
             "window_manager_service_sway.c:wm_service_sway_current_ws_to_"
@@ -348,8 +333,10 @@ int wm_service_sway_current_ws_to_output(WMServiceSway *self, WMOutput *o) {
     return sway_client_ipc_move_ws_to_output(self->socket_fd, o->name);
 }
 
-int wm_service_sway_current_app_to_workspace(WMServiceSway *self,
+int wm_service_sway_current_app_to_workspace(WindowManager *wm,
                                              WMWorkspace *ws) {
+    WMServiceSway *self = wm->private;
+
     if (!ws) {
         g_warning(
             "window_manager_service_sway.c:wm_service_sway_current_app_to_"
@@ -360,6 +347,65 @@ int wm_service_sway_current_app_to_workspace(WMServiceSway *self,
     return sway_client_ipc_move_app_to_workspace(self->socket_fd, ws->name);
 }
 
-// Get the global wm service
-// Will return NULL if `wm_service_sway_global_init` has not been called.
-WMServiceSway *wm_service_sway_get_global() { return global; };
+guint wm_service_sway_register_on_workspaces_changed(
+    WindowManager *wm, wm_on_workspaces_changed cb, void *data) {
+    WMServiceSway *self = wm->private;
+
+    return g_signal_connect(self, "workspaces-changed", G_CALLBACK(cb), self);
+}
+
+guint wm_service_sway_unregister_on_workspaces_changed(
+    WindowManager *wm, wm_on_workspaces_changed cb, void *data) {
+    WMServiceSway *self = wm->private;
+
+    return g_signal_handlers_disconnect_by_func(self, cb, self);
+}
+
+guint wm_service_sway_register_on_outputs_changed(WindowManager *wm,
+                                                  wm_on_outputs_changed cb,
+                                                  void *data) {
+    WMServiceSway *self = wm->private;
+
+    return g_signal_connect(self, "outputs-changed", G_CALLBACK(cb), self);
+}
+
+guint wm_service_sway_unregister_on_outputs_changed(WindowManager *wm,
+                                                    wm_on_outputs_changed cb,
+                                                    void *data) {
+    WMServiceSway *self = wm->private;
+
+    return g_signal_handlers_disconnect_by_func(self, cb, self);
+}
+
+WindowManager *wm_service_sway_window_manager_init() {
+    WindowManager *wm = g_malloc(sizeof(WindowManager));
+
+    WMServiceSway *self = g_object_new(WM_SERVICE_SWAY_TYPE, NULL);
+
+    wm->private = self;
+    wm->get_workspaces = wm_service_sway_get_workspaces;
+    wm->get_outputs = wm_service_sway_get_outputs;
+    wm->focus_workspace = wm_service_sway_focus_workspace;
+    wm->current_ws_to_output = wm_service_sway_current_ws_to_output;
+    wm->current_app_to_workspace = wm_service_sway_current_app_to_workspace;
+    wm->register_on_workspaces_changed =
+        wm_service_sway_register_on_workspaces_changed;
+    wm->unregister_on_workspaces_changed =
+        wm_service_sway_unregister_on_workspaces_changed;
+    wm->register_on_outputs_changed =
+        wm_service_sway_register_on_outputs_changed;
+    wm->unregister_on_outputs_changed =
+        wm_service_sway_unregister_on_outputs_changed;
+
+    // subscribe to desired events
+    sway_client_ipc_subscribe_req(
+        self->socket_fd, (int[]){IPC_EVENT_WORKSPACE, IPC_EVENT_OUTPUT}, 2);
+
+    // get initial listing of workspaces
+    sway_client_ipc_get_workspaces_req(self->socket_fd);
+
+    // get initial listing of outputs
+    sway_client_ipc_get_outputs_req(self->socket_fd);
+
+    return wm;
+}

--- a/src/services/window_manager_service/sway/window_manager_service_sway.h
+++ b/src/services/window_manager_service/sway/window_manager_service_sway.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <adwaita.h>
+
 #include "../window_manager_service.h"
 
 G_BEGIN_DECLS
@@ -11,28 +12,31 @@ G_DECLARE_FINAL_TYPE(WMServiceSway, wm_service_sway, WM_SERVICE, SWAY, GObject);
 
 G_END_DECLS
 
-// Initializes the sway wm service.
-int wm_service_sway_global_init(void);
+// // Initializes the sway wm service.
+// int wm_service_sway_global_init(void);
 
-// Get the global wm service
-// Will return NULL if `wm_service_sway_global_init` has not been called.
-WMServiceSway *wm_service_sway_get_global();
+WindowManager *wm_service_sway_window_manager_init();
 
-// Returns an array of WMWorkspace pointers representing the current workspaces
-// and their state in the window manager.
-GPtrArray *wm_service_sway_get_workspaces(WMServiceSway *self);
-
-// Returns an array of WMOutput pointers representing the current outputs
-// and their state in the window manager.
-GPtrArray *wm_service_sway_get_outputs(WMServiceSway *self);
-
-// Attempts to focus the provided workspace name.
-int wm_service_sway_focus_workspace(WMServiceSway *self, WMWorkspace *ws);
-
-// Moves the currently focused workspace to WMOutput.
-// WMServiceSway tracks the currently focused workspace internally.
-int wm_service_sway_current_ws_to_output(WMServiceSway *self, WMOutput *o);
-
-// Moves the currently focused app to the provided workspace.
-// WMServiceSway tracks the currently focused app internally.
-int wm_service_sway_current_app_to_workspace(WMServiceSway *self, WMWorkspace *ws);
+// // Get the global wm service
+// // Will return NULL if `wm_service_sway_global_init` has not been called.
+// WMServiceSway *wm_service_sway_get_global();
+//
+// // Returns an array of WMWorkspace pointers representing the current workspaces
+// // and their state in the window manager.
+// GPtrArray *wm_service_sway_get_workspaces(WMServiceSway *self);
+//
+// // Returns an array of WMOutput pointers representing the current outputs
+// // and their state in the window manager.
+// GPtrArray *wm_service_sway_get_outputs(WMServiceSway *self);
+//
+// // Attempts to focus the provided workspace name.
+// int wm_service_sway_focus_workspace(WMServiceSway *self, WMWorkspace *ws);
+//
+// // Moves the currently focused workspace to WMOutput.
+// // WMServiceSway tracks the currently focused workspace internally.
+// int wm_service_sway_current_ws_to_output(WMServiceSway *self, WMOutput *o);
+//
+// // Moves the currently focused app to the provided workspace.
+// // WMServiceSway tracks the currently focused app internally.
+// int wm_service_sway_current_app_to_workspace(WMServiceSway *self,
+//                                              WMWorkspace *ws);

--- a/src/services/window_manager_service/sway/window_manager_service_sway.h
+++ b/src/services/window_manager_service/sway/window_manager_service_sway.h
@@ -12,31 +12,5 @@ G_DECLARE_FINAL_TYPE(WMServiceSway, wm_service_sway, WM_SERVICE, SWAY, GObject);
 
 G_END_DECLS
 
-// // Initializes the sway wm service.
-// int wm_service_sway_global_init(void);
-
 WindowManager *wm_service_sway_window_manager_init();
 
-// // Get the global wm service
-// // Will return NULL if `wm_service_sway_global_init` has not been called.
-// WMServiceSway *wm_service_sway_get_global();
-//
-// // Returns an array of WMWorkspace pointers representing the current workspaces
-// // and their state in the window manager.
-// GPtrArray *wm_service_sway_get_workspaces(WMServiceSway *self);
-//
-// // Returns an array of WMOutput pointers representing the current outputs
-// // and their state in the window manager.
-// GPtrArray *wm_service_sway_get_outputs(WMServiceSway *self);
-//
-// // Attempts to focus the provided workspace name.
-// int wm_service_sway_focus_workspace(WMServiceSway *self, WMWorkspace *ws);
-//
-// // Moves the currently focused workspace to WMOutput.
-// // WMServiceSway tracks the currently focused workspace internally.
-// int wm_service_sway_current_ws_to_output(WMServiceSway *self, WMOutput *o);
-//
-// // Moves the currently focused app to the provided workspace.
-// // WMServiceSway tracks the currently focused app internally.
-// int wm_service_sway_current_app_to_workspace(WMServiceSway *self,
-//                                              WMWorkspace *ws);

--- a/src/services/window_manager_service/window_manager_service.c
+++ b/src/services/window_manager_service/window_manager_service.c
@@ -2,7 +2,7 @@
 
 #include "./sway/window_manager_service_sway.h"
 
-WindowManager *global = NULL;
+static WindowManager *global = NULL;
 
 char *WMWorkspaceEventStringTbl[WMWORKSPACE_EVENT_LEN] = {
     "CREATED", "DESTROYED", "FOCUSED", "MOVED", "RENAMED", "URGENT", "RELOAD",

--- a/src/services/window_manager_service/window_manager_service.c
+++ b/src/services/window_manager_service/window_manager_service.c
@@ -1,5 +1,29 @@
 #include "window_manager_service.h"
 
+#include "./sway/window_manager_service_sway.h"
+
+WindowManager *global = NULL;
+
 char *WMWorkspaceEventStringTbl[WMWORKSPACE_EVENT_LEN] = {
     "CREATED", "DESTROYED", "FOCUSED", "MOVED", "RENAMED", "URGENT", "RELOAD",
 };
+
+// Initialize the window manager service
+int window_manager_service_init() {
+    GSettings *settings =
+        g_settings_new("org.ldelossa.way-shell.window-manager");
+
+    char *backend = g_settings_get_string(settings, "backend");
+
+    if (g_strcmp0(backend, "sway") == 0) {
+        global = wm_service_sway_window_manager_init();
+    } else {
+        g_warning("Unknown backend: %s", backend);
+        return -1;
+    }
+    return 0;
+}
+
+// Obtain the global window manager service, a call to
+// `window_manager_service_init` must be made before this.
+WindowManager *window_manager_service_get_global() { return global; }

--- a/src/services/window_manager_service/window_manager_service.h
+++ b/src/services/window_manager_service/window_manager_service.h
@@ -61,3 +61,73 @@ typedef struct _WMOutput {
     gchar *serial;
     gchar *current_workspace;
 } WMOutput;
+
+// WinowManager is a virtual function table which abstracts an underlying
+// window manager implementation.
+//
+// Each implementation should define a function which returns a WindowManager
+// with its method's set to internal function pointers.
+typedef struct _WindowManager WindowManager;
+typedef GPtrArray *(*wm_get_workspaces_func)(WindowManager *self);
+
+typedef GPtrArray *(*wm_get_outputs_func)(WindowManager *self);
+
+typedef int (*wm_focus_workspace_func)(WindowManager *self, WMWorkspace *ws);
+
+typedef int (*wm_current_ws_to_output_func)(WindowManager *self, WMOutput *o);
+
+typedef int (*wm_current_app_to_workspace_func)(WindowManager *self,
+                                                WMWorkspace *ws);
+
+typedef void (*wm_on_workspaces_changed)(WindowManager *self,
+                                         GPtrArray *workspaces, void *data);
+typedef void (*wm_on_outputs_changed)(WindowManager *self, GPtrArray *outputs,
+                                      void *data);
+
+typedef guint (*wm_register_on_workspaces_changed)(WindowManager *self,
+                                                   wm_on_workspaces_changed cb,
+                                                   void *data);
+
+typedef guint (*wm_unregister_on_workspaces_changed)(
+    WindowManager *self, wm_on_workspaces_changed cb, void *data);
+
+typedef guint (*wm_register_on_outputs_changed)(WindowManager *self,
+                                                wm_on_outputs_changed cb,
+                                                void *data);
+
+typedef guint (*wm_unregister_on_outputs_changed)(WindowManager *self,
+                                                  wm_on_outputs_changed cb,
+                                                  void *data);
+
+typedef struct _WindowManager {
+    // private struct which implements the WindowManager interface, interface
+    // methods below can cast this to their internal type.
+    void *private;
+    // Provide a list of currently available workspaces
+    wm_get_workspaces_func get_workspaces;
+    // Provide a list of currently available outputs
+    wm_get_outputs_func get_outputs;
+    // Focus the provided workspace
+    wm_focus_workspace_func focus_workspace;
+    // Move the current workspace to the specified output
+    wm_current_ws_to_output_func current_ws_to_output;
+    // Move the current app to the specified workspace
+    wm_current_app_to_workspace_func current_app_to_workspace;
+    // register a callback when workspaces has changed.
+    // returns the GObject signal ID on success.
+    wm_register_on_workspaces_changed register_on_workspaces_changed;
+    // unregister a callback when workspaces has changed.
+    wm_unregister_on_workspaces_changed unregister_on_workspaces_changed;
+    // register a callback when outputs has changed.
+    // returns the GObject signal ID on success.
+    wm_register_on_outputs_changed register_on_outputs_changed;
+    // unregister a callback when outputs has changed.
+    wm_unregister_on_outputs_changed unregister_on_outputs_changed;
+} WindowManager;
+
+// Initialize the window manager service
+int window_manager_service_init();
+
+// Obtain the global window manager service, a call to
+// `window_manager_service_init` must be made before this.
+WindowManager *window_manager_service_get_global();

--- a/src/services/window_manager_service/window_manager_service.h
+++ b/src/services/window_manager_service/window_manager_service.h
@@ -79,10 +79,9 @@ typedef int (*wm_current_ws_to_output_func)(WindowManager *self, WMOutput *o);
 typedef int (*wm_current_app_to_workspace_func)(WindowManager *self,
                                                 WMWorkspace *ws);
 
-typedef void (*wm_on_workspaces_changed)(WindowManager *self,
-                                         GPtrArray *workspaces, void *data);
-typedef void (*wm_on_outputs_changed)(WindowManager *self, GPtrArray *outputs,
-                                      void *data);
+typedef void (*wm_on_workspaces_changed)(void *data, GPtrArray *workspaces);
+
+typedef void (*wm_on_outputs_changed)(void *data, GPtrArray *outputs);
 
 typedef guint (*wm_register_on_workspaces_changed)(WindowManager *self,
                                                    wm_on_workspaces_changed cb,


### PR DESCRIPTION
This pull requests introduces an abstraction layer for window managers. 

In this PR a single backend is implemented, Sway. 

By following the Sway implementation other backends  such as Niri and Hyperland should be possible. 

It should be noted that the abstraction layer was written with Sway as a first class citizen. While its rather small and seems simple, tweaks may need to be considered when implementing other window manager backends. 