### PR TITLE
refactor: fix various overflows

### DIFF
--- a/data/theme/way-shell-dark.css
+++ b/data/theme/way-shell-dark.css
@@ -1024,15 +1024,16 @@ label.day-number.today:focus {
 
 #workspace-switcher #search-entry {
     margin: 20px;
-    margin-bottom: 0px;
+    margin-bottom: 5px;
     padding: 8px;
     border-radius: 10px;
 }
 
 #workspace-switcher #workspace-list {
-    background: @top-panel-background;
+    background: @base-panel-background;
     margin: 20px;
     border-radius: 20px;
+	margin-bottom: 40px;
 }
 
 #workspace-switcher row:selected {
@@ -1071,13 +1072,13 @@ label.day-number.today:focus {
 
 #output-switcher #search-entry {
     margin: 20px;
-    margin-bottom: 0px;
+    margin-bottom: 5px;
     padding: 8px;
     border-radius: 10px;
 }
 
 #output-switcher #output-list {
-    background: @top-panel-background;
+    background: @base-panel-background;
     margin: 20px;
     border-radius: 20px;
 }

--- a/data/theme/way-shell-light.css
+++ b/data/theme/way-shell-light.css
@@ -1066,13 +1066,13 @@ statuspage {
 
 #workspace-switcher #search-entry {
     margin: 20px;
-    margin-bottom: 0px;
+    margin-bottom: 5px;
     padding: 8px;
     border-radius: 10px;
 }
 
 #workspace-switcher #workspace-list {
-    background: @top-panel-background;
+    background: @base-panel-background;
     margin: 20px;
     border-radius: 20px;
 }
@@ -1113,13 +1113,13 @@ statuspage {
 
 #output-switcher #search-entry {
     margin: 20px;
-    margin-bottom: 0px;
+    margin-bottom: 5px;
     padding: 8px;
     border-radius: 10px;
 }
 
 #output-switcher #output-list {
-    background: @top-panel-background;
+    background: @base-panel-background;
     margin: 20px;
     border-radius: 20px;
 }

--- a/src/app_switcher/app_switcher.c
+++ b/src/app_switcher/app_switcher.c
@@ -17,6 +17,7 @@ enum signals { signals_n };
 typedef struct _AppSwitcher {
     GObject parent_instance;
     AdwWindow *win;
+	GtkScrolledWindow *scrolled;
     GtkBox *app_widget_list;
     GtkEventController *key_controller;
     int widget_n;
@@ -209,10 +210,18 @@ static void app_switcher_init_layout(AppSwitcher *self) {
     gtk_layer_set_keyboard_mode(GTK_WINDOW(self->win),
                                 GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
 
+	self->scrolled = GTK_SCROLLED_WINDOW(gtk_scrolled_window_new());
+    gtk_scrolled_window_set_max_content_width(self->scrolled, 1400);
+    gtk_scrolled_window_set_max_content_height(self->scrolled, -1);
+    gtk_scrolled_window_set_propagate_natural_height(self->scrolled, 1);
+	gtk_scrolled_window_set_propagate_natural_width(self->scrolled, 1);
+
     self->app_widget_list = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
     gtk_widget_set_name(GTK_WIDGET(self->app_widget_list), "app-switcher-list");
 
-    adw_window_set_content(self->win, GTK_WIDGET(self->app_widget_list));
+	gtk_scrolled_window_set_child(self->scrolled, GTK_WIDGET(self->app_widget_list));
+
+    adw_window_set_content(self->win, GTK_WIDGET(self->scrolled));
 
     // listen for toplevels from wayland service
     WaylandService *wayland = wayland_service_get_global();

--- a/src/app_switcher/app_switcher_app_widget.c
+++ b/src/app_switcher/app_switcher_app_widget.c
@@ -7,6 +7,7 @@
 
 #include "./../services/wayland_service/wayland_service.h"
 #include "./app_switcher.h"
+#include "gtk/gtk.h"
 
 enum signals { signals_n };
 
@@ -28,6 +29,7 @@ typedef struct _AppSwitcherAppWidget {
     GtkImage *icon;
     GtkLabel *id_or_title;
     GtkImage *expand_arrow;
+    GtkScrolledWindow *scrolled;
     GtkBox *instances_container;
     mouse_coords mouse;
     gint focused_index;
@@ -156,8 +158,17 @@ static void app_switcher_app_widget_init_layout(AppSwitcherAppWidget *self) {
     gtk_label_set_ellipsize(self->id_or_title, PANGO_ELLIPSIZE_START);
     gtk_label_set_xalign(self->id_or_title, 0.5);
 
+    self->scrolled = GTK_SCROLLED_WINDOW(gtk_scrolled_window_new());
+    gtk_scrolled_window_set_max_content_width(self->scrolled, 1200);
+    gtk_scrolled_window_set_max_content_height(self->scrolled, -1);
+    gtk_scrolled_window_set_propagate_natural_height(self->scrolled, 1);
+	gtk_scrolled_window_set_propagate_natural_width(self->scrolled, 1);
+
     self->instances_container =
         GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+
+    gtk_scrolled_window_set_child(self->scrolled,
+                                  GTK_WIDGET(self->instances_container));
 
     // wire the widget up
     gtk_box_append(self->button_contents, GTK_WIDGET(self->icon));
@@ -167,7 +178,7 @@ static void app_switcher_app_widget_init_layout(AppSwitcherAppWidget *self) {
     gtk_box_append(self->container, GTK_WIDGET(self->button));
     gtk_box_append(self->container, GTK_WIDGET(self->expand_arrow));
 
-    adw_window_set_content(self->win, GTK_WIDGET(self->instances_container));
+    adw_window_set_content(self->win, GTK_WIDGET(self->scrolled));
 }
 
 static void app_switcher_app_widget_init(AppSwitcherAppWidget *self) {
@@ -362,6 +373,7 @@ void app_switcher_app_widget_set_focused(AppSwitcherAppWidget *self,
     }
 
     gtk_widget_add_css_class(GTK_WIDGET(self->button), "selected");
+	gtk_widget_grab_focus(GTK_WIDGET(self->button));
 }
 
 void app_switcher_app_widget_set_focused_next_instance(

--- a/src/output_switcher/output_switcher.c
+++ b/src/output_switcher/output_switcher.c
@@ -17,6 +17,7 @@ typedef struct _OutputSwitcher {
     GObject parent_instance;
     AdwWindow *win;
 
+    GtkScrolledWindow *scrolled;
     // List model and filtering
     GtkListBox *output_list;
 
@@ -112,6 +113,7 @@ static void on_search_next_match(GtkSearchEntry *entry, OutputSwitcher *self) {
     if (!next_row) next_row = output_switcher_top_choice(self);
 
     gtk_list_box_select_row(self->output_list, next_row);
+    gtk_widget_grab_focus(GTK_WIDGET(next_row));
 }
 
 static void on_search_previous_match(GtkSearchEntry *entry,
@@ -126,6 +128,7 @@ static void on_search_previous_match(GtkSearchEntry *entry,
     if (!next_row) next_row = output_switcher_last_choice(self);
 
     gtk_list_box_select_row(self->output_list, next_row);
+    gtk_widget_grab_focus(GTK_WIDGET(next_row));
 }
 
 static void on_search_activated(GtkSearchEntry *entry, OutputSwitcher *self) {
@@ -337,14 +340,22 @@ static void output_switcher_init_layout(OutputSwitcher *self) {
     g_signal_connect(self->search_entry, "previous-match",
                      G_CALLBACK(on_search_previous_match), self);
 
+    self->scrolled = GTK_SCROLLED_WINDOW(gtk_scrolled_window_new());
+    gtk_scrolled_window_set_max_content_height(self->scrolled, 400);
+    gtk_scrolled_window_set_propagate_natural_height(self->scrolled, 1);
+    gtk_scrolled_window_set_propagate_natural_width(self->scrolled, 1);
+
     self->output_list = GTK_LIST_BOX(gtk_list_box_new());
     gtk_widget_set_name(GTK_WIDGET(self->output_list), "output-list");
     gtk_widget_set_hexpand(GTK_WIDGET(self->output_list), true);
     gtk_widget_set_vexpand(GTK_WIDGET(self->output_list), true);
 
+    gtk_scrolled_window_set_child(self->scrolled,
+                                  GTK_WIDGET(self->output_list));
+
     // wire it up
     gtk_box_append(self->container, GTK_WIDGET(search_container));
-    gtk_box_append(self->container, GTK_WIDGET(self->output_list));
+    gtk_box_append(self->container, GTK_WIDGET(self->scrolled));
 
     // get listings of outputs
     WindowManager *wm = window_manager_service_get_global();

--- a/src/workspace_switcher/workspace_switcher.c
+++ b/src/workspace_switcher/workspace_switcher.c
@@ -23,6 +23,7 @@ typedef struct _WorkspaceSwitcher {
     AdwWindow *win;
     enum mode mode;
 
+	GtkScrolledWindow *scrolled;
     // List model and filtering
     GtkListBox *workspace_list;
 
@@ -119,6 +120,7 @@ static void on_search_next_match(GtkSearchEntry *entry,
     if (!next_row) next_row = workspace_switcher_top_choice(self);
 
     gtk_list_box_select_row(self->workspace_list, next_row);
+	gtk_widget_grab_focus(GTK_WIDGET(next_row));
 }
 
 static void on_search_previous_match(GtkSearchEntry *entry,
@@ -133,6 +135,7 @@ static void on_search_previous_match(GtkSearchEntry *entry,
     if (!next_row) next_row = workspace_switcher_last_choice(self);
 
     gtk_list_box_select_row(self->workspace_list, next_row);
+	gtk_widget_grab_focus(GTK_WIDGET(next_row));
 }
 
 static void on_search_activated_app_mode(GtkSearchEntry *entry,
@@ -402,14 +405,21 @@ static void workspace_switcher_init_layout(WorkspaceSwitcher *self) {
     g_signal_connect(self->search_entry, "previous-match",
                      G_CALLBACK(on_search_previous_match), self);
 
+	self->scrolled = GTK_SCROLLED_WINDOW(gtk_scrolled_window_new());
+    gtk_scrolled_window_set_max_content_height(self->scrolled, 400);
+    gtk_scrolled_window_set_propagate_natural_height(self->scrolled, 1);
+	gtk_scrolled_window_set_propagate_natural_width(self->scrolled, 1);
+
     self->workspace_list = GTK_LIST_BOX(gtk_list_box_new());
     gtk_widget_set_name(GTK_WIDGET(self->workspace_list), "workspace-list");
     gtk_widget_set_hexpand(GTK_WIDGET(self->workspace_list), true);
     gtk_widget_set_vexpand(GTK_WIDGET(self->workspace_list), true);
 
+	gtk_scrolled_window_set_child(self->scrolled, GTK_WIDGET(self->workspace_list));
+
     // wire it up
     gtk_box_append(self->container, GTK_WIDGET(search_container));
-    gtk_box_append(self->container, GTK_WIDGET(self->workspace_list));
+    gtk_box_append(self->container, GTK_WIDGET(self->scrolled));
 
     // get listings of workspaces
     WindowManager *wm = window_manager_service_get_global();


### PR DESCRIPTION
Fixes some overflows of the screen's dimensions. 

All UI elements should always scroll instead of overflowing the screen.
This PR ensures this for workspace, monitor, and app switchers.