### PR TITLE
fix use of logind's ListSessions

### DIFF
--- a/src/services/logind_service/logind_service.c
+++ b/src/services/logind_service/logind_service.c
@@ -71,13 +71,13 @@ static void logind_service_session_dbus_connect(LogindService *self) {
     while (g_variant_iter_loop(iter, "@(susso)", &session_variant)) {
         gchar *id;
         guint32 sess_uid;
+        gchar *username;
         gchar *seat;
-        gchar *display;
         gchar *obj_path;
-        g_variant_get(session_variant, "(susso)", &id, &sess_uid, &seat,
-                      &display, &obj_path);
+        g_variant_get(session_variant, "(susso)", &id, &sess_uid, &username,
+                      &seat, &obj_path);
 
-        if (!seat) continue;
+        if (strlen(seat) == 0) continue;
 
         session = dbus_login1_session_proxy_new_sync(
             self->conn, G_DBUS_PROXY_FLAGS_NONE, "org.freedesktop.login1",


### PR DESCRIPTION
from the man page:
ListSessions() returns an array of all current sessions. The structures in the array consist of the following fields: session id, user id, user name, seat id, and session object path.
If a session does not have a seat attached, the seat id field will be an empty string.

This should be the end of the seat selection debacle :P