### PR TITLE
quick-settings,nm: add VPN toggling via quick settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,4 @@ Feel free to adjust these to your liking.
 - [x] App/Workspace switcher (alt+tab)
 - [x] Workspace Overview/Application launcher overlay widget
 - [ ] Option to turn on idle inhibitor when video/audio sources are detected.
+- [x] Network Manager VPN integration in quick settings (toggle VPN's on an off).

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.c
@@ -8,6 +8,7 @@
 #include "./quick_settings_grid_night_light/quick_settings_grid_night_light.h"
 #include "./quick_settings_grid_power_profiles/quick_settings_grid_power_profiles.h"
 #include "./quick_settings_grid_theme.h"
+#include "./quick_settings_grid_vpn/quick_settings_grid_vpn.h"
 #include "./quick_settings_grid_wifi/quick_settings_grid_wifi.h"
 #include "./quick_settings_keyboard_brightness/quick_settings_grid_keyboard_brightness.h"
 #include "gtk/gtkrevealer.h"
@@ -205,6 +206,10 @@ void quick_settings_grid_button_free(QuickSettingsGridButton *self) {
         case QUICK_SETTINGS_BUTTON_KEYBOARD_BRIGHTNESS:
             quick_settings_grid_keyboard_brightness_button_free(
                 (QuickSettingsGridKeyboardBrightnessButton *)self);
+            break;
+        case QUICK_SETTINGS_BUTTON_VPN:
+            quick_settings_grid_vpn_button_free(
+                (QuickSettingsGridVPNButton *)self);
             break;
     }
 }

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.h
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.h
@@ -13,6 +13,7 @@ enum QuickSettingsButtonType {
     QUICK_SETTINGS_BUTTON_NIGHT_LIGHT,
     QUICK_SETTINGS_BUTTON_AIRPLANE_MODE,
     QUICK_SETTINGS_BUTTON_KEYBOARD_BRIGHTNESS,
+    QUICK_SETTINGS_BUTTON_VPN,
 };
 
 typedef struct _QuickSettingsGridCluster QuickSettingsGridCluster;

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn.c
@@ -1,0 +1,95 @@
+#include "./quick_settings_grid_vpn.h"
+
+#include <adwaita.h>
+
+#include "../../../../services/network_manager_service.h"
+#include "./../quick_settings_grid_button.h"
+
+static void on_toggle_button_clicked(GtkToggleButton *toggle_button,
+                                     QuickSettingsGridVPNButton *self) {
+    g_debug("quick_settings_grid_vpn.c:on_toggle_button_clicked() called");
+    self->enabled = !self->enabled;
+}
+
+void quick_settings_grid_vpn_button_layout(QuickSettingsGridVPNButton *self) {
+    // create associated menu
+    self->menu = g_object_new(QUICK_SETTINGS_GRID_VPN_MENU_TYPE, NULL);
+
+    quick_settings_grid_button_init(
+        &self->button, QUICK_SETTINGS_BUTTON_VPN, "VPN", "",
+        "network-vpn-disconnected-symbolic",
+        quick_settings_grid_vpn_button_get_menu_widget(self),
+        quick_settings_grid_vpn_menu_on_reveal);
+
+    // write into toggle button's click event
+    g_signal_connect(self->button.toggle, "clicked",
+                     G_CALLBACK(on_toggle_button_clicked), self);
+}
+
+static void on_vpn_activated(NetworkManagerService *nm,
+                             NMActiveConnection *vpn_conn,
+                             QuickSettingsGridVPNButton *self) {
+    g_debug("quick_settings_grid_vpn.c:on_vpn_activated() called");
+
+    const gchar *id = nm_active_connection_get_id(vpn_conn);
+
+    gtk_label_set_text(self->button.subtitle, id);
+    gtk_image_set_from_icon_name(self->button.icon, "network-vpn-symbolic");
+
+    quick_settings_grid_button_set_toggled(&self->button, true);
+}
+
+static void on_vpn_deactivated(NetworkManagerService *nm,
+                               NMActiveConnection *vpn_conn,
+                               QuickSettingsGridVPNButton *self) {
+    g_debug("quick_settings_grid_vpn.c:on_vpn_deactivated() called");
+    gtk_label_set_text(self->button.subtitle, "");
+    gtk_image_set_from_icon_name(self->button.icon,
+                                 "network-vpn-disconnected-symbolic");
+
+    quick_settings_grid_button_set_toggled(&self->button, false);
+}
+
+static void on_vpn_removed(NetworkManagerService *nm, NMConnection *vpn_conn,
+                           int len, QuickSettingsGridVPNButton *self) {
+    g_debug("quick_settings_grid_vpn.c:on_vpn_removed() called");
+    g_signal_emit_by_name(self->button.cluster, "remove_button_req", self);
+}
+
+QuickSettingsGridVPNButton *quick_settings_grid_vpn_button_init() {
+    QuickSettingsGridVPNButton *self =
+        g_malloc0(sizeof(QuickSettingsGridVPNButton));
+
+    quick_settings_grid_vpn_button_layout(self);
+
+    NetworkManagerService *nm = network_manager_service_get_global();
+    g_signal_connect(nm, "vpn-removed", G_CALLBACK(on_vpn_removed), self);
+    g_signal_connect(nm, "vpn-activated", G_CALLBACK(on_vpn_activated), self);
+    g_signal_connect(nm, "vpn-deactivated", G_CALLBACK(on_vpn_deactivated),
+                     self);
+
+    quick_settings_grid_button_set_toggled(&self->button, false);
+
+    return self;
+}
+
+GtkWidget *quick_settings_grid_vpn_button_get_menu_widget(
+    QuickSettingsGridVPNButton *self) {
+    return GTK_WIDGET(quick_settings_grid_vpn_menu_get_widget(self->menu));
+}
+
+void quick_settings_grid_vpn_button_free(QuickSettingsGridVPNButton *self) {
+    g_debug("quick_settings_grid_vpn.c:qs_grid_wifi_button_free() called");
+
+    // kill network manager signals
+    NetworkManagerService *nm = network_manager_service_get_global();
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_activated, self);
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_deactivated, self);
+
+    // unref our menu
+    g_object_unref(self->menu);
+    // unref button's container
+    g_object_unref(self->button.container);
+    // free ourselves
+    g_free(self);
+}

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn.h
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <NetworkManager.h>
+#include <adwaita.h>
+
+#include "../quick_settings_grid_button.h"
+#include "quick_settings_grid_vpn_menu.h"
+
+#define QUICK_SETTINGS_VPN_TYPE "vpn"
+
+typedef struct _QuickSesstingsGridVPNButton {
+    // embedd this as first argument so we can cast to it.
+    QuickSettingsGridButton button;
+    QuickSettingsGridVPNMenu *menu;
+    gboolean enabled;
+
+} QuickSettingsGridVPNButton;
+
+QuickSettingsGridVPNButton *quick_settings_grid_vpn_button_init();
+
+void quick_settings_grid_vpn_button_free(QuickSettingsGridVPNButton *self);
+
+GtkWidget *quick_settings_grid_vpn_button_get_menu_widget(
+    QuickSettingsGridVPNButton *self);
+
+void quick_settings_grid_vpn_menu_on_reveal(
+    QuickSettingsGridButton *button, gboolean is_revealed);

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn_menu.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn_menu.c
@@ -1,0 +1,214 @@
+#include "quick_settings_grid_vpn_menu.h"
+
+#include <NetworkManager.h>
+#include <adwaita.h>
+
+#include "../../../../services/network_manager_service.h"
+#include "../../quick_settings.h"
+#include "../../quick_settings_menu_widget.h"
+#include "glib-object.h"
+#include "gtk/gtk.h"
+#include "nm-core-types.h"
+#include "quick_settings_grid_vpn.h"
+
+enum signals { signals_n };
+
+typedef struct _QuickSettingsGridVPNMenu {
+    GObject parent_instance;
+    QuickSettingsMenuWidget menu;
+    GHashTable *vpn_conns;
+} QuickSettingsGridVPNMenu;
+G_DEFINE_TYPE(QuickSettingsGridVPNMenu, quick_settings_grid_vpn_menu,
+              G_TYPE_OBJECT);
+
+// foward declarations for network manager signal handlers
+static void on_vpn_added(NetworkManagerService *nm, NMConnection *vpn_conn,
+                         int len, QuickSettingsGridVPNMenu *self);
+static void on_vpn_removed(NetworkManagerService *nm, NMConnection *vpn_conn,
+                           int len, QuickSettingsGridVPNMenu *self);
+static void on_vpn_activated(NetworkManagerService *nm,
+                             NMActiveConnection *vpn_conn,
+                             QuickSettingsGridVPNMenu *self);
+static void on_vpn_deactivated(NetworkManagerService *nm,
+                               NMActiveConnection *vpn_conn,
+                               QuickSettingsGridVPNMenu *self);
+
+// stub out dispose, finalize, init and class init functions for GObject
+static void quick_settings_grid_vpn_menu_dispose(GObject *object) {
+    QuickSettingsGridVPNMenu *self = QUICK_SETTINGS_GRID_VPN_MENU(object);
+
+    NetworkManagerService *nm = network_manager_service_get_global();
+
+    // disconnect from signals
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_added, self);
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_removed, self);
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_activated, self);
+    g_signal_handlers_disconnect_by_func(nm, on_vpn_deactivated, self);
+
+    // free vpn_conns hash table
+    g_hash_table_destroy(self->vpn_conns);
+
+    G_OBJECT_CLASS(quick_settings_grid_vpn_menu_parent_class)->dispose(object);
+}
+
+static void quick_settings_grid_vpn_menu_finalize(GObject *object) {}
+
+static void quick_settings_grid_vpn_menu_class_init(
+    QuickSettingsGridVPNMenuClass *klass) {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->dispose = quick_settings_grid_vpn_menu_dispose;
+    object_class->finalize = quick_settings_grid_vpn_menu_finalize;
+}
+
+static void on_vpn_conn_widget_activate(AdwSwitchRow *row, GParamSpec *spec,
+                                        QuickSettingsGridVPNMenu *self) {
+    // activating the switch is a trigger to connect to the VPN.
+    // Therefore, when we see the switch 'activated' we immediately
+    // deactivate it and then attempt to connect to the vpn associated with
+    // the id.
+    const gchar *id = adw_preferences_row_get_title(ADW_PREFERENCES_ROW(row));
+    gboolean activated = adw_switch_row_get_active(row);
+
+    NetworkManagerService *nm = network_manager_service_get_global();
+
+    if (activated) {
+        network_manager_activate_vpn(nm, id, true);
+    } else {
+        network_manager_activate_vpn(nm, id, false);
+    }
+}
+
+GtkWidget *new_vpn_conn_row(NMConnection *vpn_con,
+                            QuickSettingsGridVPNMenu *self) {
+    GtkWidget *row = adw_switch_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row),
+                                  nm_connection_get_id(vpn_con));
+    gtk_widget_add_css_class(GTK_WIDGET(row), "switch-row-vpn");
+
+    g_signal_connect(row, "notify::active",
+                     G_CALLBACK(on_vpn_conn_widget_activate), self);
+
+    return row;
+}
+
+static void on_vpn_added(NetworkManagerService *nm, NMConnection *vpn_conn,
+                         int len, QuickSettingsGridVPNMenu *self) {
+    // add a new VPN Switch Row Widget
+    GtkWidget *row = new_vpn_conn_row(vpn_conn, self);
+
+    g_hash_table_insert(self->vpn_conns,
+                        g_strdup(nm_connection_get_id(vpn_conn)), row);
+
+    gtk_box_append(self->menu.options, row);
+}
+
+static void on_vpn_removed(NetworkManagerService *nm, NMConnection *vpn_conn,
+                           int len, QuickSettingsGridVPNMenu *self) {
+    // remove the VPN Swithc Row Widget if it exists
+    GtkWidget *row =
+        g_hash_table_lookup(self->vpn_conns, nm_connection_get_id(vpn_conn));
+    if (row) {
+        gtk_box_remove(self->menu.options, row);
+        g_hash_table_remove(self->vpn_conns, nm_connection_get_id(vpn_conn));
+    }
+}
+
+static void disable_other_rows(GtkWidget *enabled,
+                               QuickSettingsGridVPNMenu *self) {
+    GtkWidget *child =
+        gtk_widget_get_first_child(GTK_WIDGET(self->menu.options));
+    while (child) {
+        if (child != enabled) {
+            gtk_widget_set_sensitive(child, false);
+            gtk_widget_set_focusable(child, false);
+        }
+        child = gtk_widget_get_next_sibling(child);
+    }
+}
+
+static void enable_all_rows(QuickSettingsGridVPNMenu *self) {
+    GtkWidget *child =
+        gtk_widget_get_first_child(GTK_WIDGET(self->menu.options));
+    while (child) {
+        gtk_widget_set_sensitive(child, true);
+        child = gtk_widget_get_next_sibling(child);
+    }
+}
+
+static void on_vpn_activated(NetworkManagerService *nm,
+                             NMActiveConnection *vpn_conn,
+                             QuickSettingsGridVPNMenu *self) {
+    // find row widget by connection id
+    GtkWidget *row = g_hash_table_lookup(self->vpn_conns,
+                                         nm_active_connection_get_id(vpn_conn));
+    if (!row) return;
+
+    g_signal_handlers_block_by_func(row, on_vpn_conn_widget_activate, self);
+    adw_switch_row_set_active(ADW_SWITCH_ROW(row), TRUE);
+    g_signal_handlers_unblock_by_func(row, on_vpn_conn_widget_activate, self);
+
+    disable_other_rows(row, self);
+}
+
+static void on_vpn_deactivated(NetworkManagerService *nm,
+                               NMActiveConnection *vpn_conn,
+                               QuickSettingsGridVPNMenu *self) {
+    // find row widget by connection id
+    GtkWidget *row = g_hash_table_lookup(self->vpn_conns,
+                                         nm_active_connection_get_id(vpn_conn));
+    if (!row) return;
+
+    // receiving event so block notify::active event from firing
+    g_signal_handlers_block_by_func(row, on_vpn_conn_widget_activate, self);
+    adw_switch_row_set_active(ADW_SWITCH_ROW(row), FALSE);
+    g_signal_handlers_unblock_by_func(row, on_vpn_conn_widget_activate, self);
+
+    enable_all_rows(self);
+}
+
+static void quick_settings_grid_vpn_menu_init_layout(
+    QuickSettingsGridVPNMenu *self) {
+    quick_settings_menu_widget_init(&self->menu, false);
+    quick_settings_menu_widget_set_icon(&self->menu, "network-vpn-symbolic");
+    quick_settings_menu_widget_set_title(&self->menu, "VPN");
+
+    NetworkManagerService *nm = network_manager_service_get_global();
+
+    // Populate current VPN Networks
+    if (!network_manager_has_vpn(nm)) return;
+
+    GHashTable *vpn_conns = network_manager_get_vpn_connections(nm);
+    GList *values = g_hash_table_get_values(vpn_conns);
+    for (GList *l = values; l; l = l->next) {
+        NMConnection *vpn_conn = l->data;
+        on_vpn_added(nm, vpn_conn, 0, self);
+    }
+
+    g_signal_connect(nm, "vpn-added", G_CALLBACK(on_vpn_added), self);
+    g_signal_connect(nm, "vpn-removed", G_CALLBACK(on_vpn_removed), self);
+    g_signal_connect(nm, "vpn-activated", G_CALLBACK(on_vpn_activated), self);
+    g_signal_connect(nm, "vpn-deactivated", G_CALLBACK(on_vpn_deactivated),
+                     self);
+}
+
+static void quick_settings_grid_vpn_menu_init(QuickSettingsGridVPNMenu *self) {
+    self->vpn_conns =
+        g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    quick_settings_grid_vpn_menu_init_layout(self);
+}
+
+void quick_settings_grid_vpn_menu_on_reveal(QuickSettingsGridButton *button_,
+                                            gboolean is_revealed) {
+    QuickSettingsGridVPNButton *button = (QuickSettingsGridVPNButton *)button_;
+    QuickSettingsGridVPNMenu *self = button->menu;
+
+    if (!is_revealed) {
+    }
+
+    g_debug("quick_settings_grid_vpn_menu.c:on_reveal() called");
+}
+
+GtkWidget *quick_settings_grid_vpn_menu_get_widget(
+    QuickSettingsGridVPNMenu *self) {
+    return GTK_WIDGET(self->menu.container);
+}

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn_menu.h
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_vpn/quick_settings_grid_vpn_menu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <NetworkManager.h>
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+struct _QuickSettingsGridVPNMenu;
+#define QUICK_SETTINGS_GRID_VPN_MENU_TYPE \
+    quick_settings_grid_vpn_menu_get_type()
+G_DECLARE_FINAL_TYPE(QuickSettingsGridVPNMenu, quick_settings_grid_vpn_menu,
+                     QUICK_SETTINGS, GRID_VPN_MENU, GObject);
+
+G_END_DECLS
+
+GtkWidget *quick_settings_grid_vpn_menu_get_widget(
+    QuickSettingsGridVPNMenu *grid);

--- a/src/services/network_manager_service.h
+++ b/src/services/network_manager_service.h
@@ -3,6 +3,8 @@
 #include <NetworkManager.h>
 #include <adwaita.h>
 
+#include "nm-core-types.h"
+
 G_BEGIN_DECLS
 
 // Simple clock service which emits a 'tick' signal on every minute.
@@ -61,8 +63,15 @@ void network_manager_service_wireless_enable(NetworkManagerService *self,
 void network_manager_service_networking_enable(NetworkManagerService *self,
                                                gboolean enabled);
 
-void network_manager_service_networking_enable(NetworkManagerService *self,
-                                               gboolean enabled);
+gboolean network_manager_has_vpn(NetworkManagerService *self);
+
+GHashTable *network_manager_get_vpn_connections(NetworkManagerService *self);
+
+NMVpnConnection *network_manager_get_active_vpn_connection(
+    NetworkManagerService *self);
+
+void network_manager_activate_vpn(NetworkManagerService *self, const gchar *id,
+                                  gboolean activate);
 
 gboolean network_manager_service_get_networking_enabled(
     NetworkManagerService *self);


### PR DESCRIPTION
This commit adds a new VPN quick settings button and introduces the necessary modifications to NetworkManagerService to support it.

The button will not be spawned if no VPN connections exist in NetworkManager's database.

Once a VPN exists the VPN button will be spawned in the quick settings area with a drop down allowing particular VPN connections to be toggled on.

The VPN connection is *always* activated on the PrimaryDevice. This is typically the device your machine uses to get to the internet.