### PR TITLE
rename-switcher: introduce widget for renaming workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ bindsym $mod+Tab exec way-sh app-switcher toggle
 bindsym $mod+o exec way-sh output-switcher toggle
 bindsym $mod+w exec way-sh workspace-switcher toggle
 bindsym $mod+a exec way-sh workspace-app-switcher toggle
+bindsym $mod+r exec way-sh rename-switcher toggle
 ```
 
 ## Using Way-Shell

--- a/data/theme/way-shell-dark.css
+++ b/data/theme/way-shell-dark.css
@@ -1029,6 +1029,10 @@ label.day-number.today:focus {
     border-radius: 10px;
 }
 
+#switcher .no_list #search-entry  {
+    margin: 20px;
+}
+
 #switcher #list {
     background: @base-panel-background;
     margin: 20px;

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@
 #include "./services/window_manager_service/window_manager_service.h"
 #include "./services/wireplumber_service.h"
 #include "./workspace_switcher/workspace_switcher.h"
+#include "./rename_switcher/rename_switcher.h"
 #include "panel/panel_mediator.h"
 #include "panel/quick_settings/quick_settings.h"
 
@@ -153,6 +154,9 @@ static void activate(AdwApplication *app, gpointer user_data) {
 
     output_switcher_activate(app, user_data);
     g_debug("main.c: activate(): output_switcher subsystems activated");
+
+    rename_switcher_activate(app, user_data);
+    g_debug("main.c: activate(): rename_switcher subsystems activated");
 
     workspace_switcher_activate(app, user_data);
     g_debug("main.c: activate(): workspace_switcher subsystems activated");

--- a/src/rename_switcher/rename_switcher.c
+++ b/src/rename_switcher/rename_switcher.c
@@ -1,0 +1,134 @@
+#include "./rename_switcher.h"
+
+#include <adwaita.h>
+#include <gio/gdesktopappinfo.h>
+#include <gio/gio.h>
+#include <gtk4-layer-shell/gtk4-layer-shell.h>
+
+#include "../switcher/switcher.h"
+#include "./../services/window_manager_service/window_manager_service.h"
+#include "gdk/gdkkeysyms.h"
+
+static RenameSwitcher *global = NULL;
+
+enum signals { signals_n };
+
+enum mode {
+    switch_rename,
+    switch_app,
+};
+
+typedef struct _RenameSwitcher {
+    GObject parent_instance;
+    Switcher switcher;
+
+} RenameSwitcher;
+
+static guint rename_switcher_signals[signals_n] = {0};
+G_DEFINE_TYPE(RenameSwitcher, rename_switcher, G_TYPE_OBJECT);
+
+// stub out dispose, finalize, class_init and init methods.
+static void rename_switcher_dispose(GObject *object) {
+    G_OBJECT_CLASS(rename_switcher_parent_class)->dispose(object);
+}
+
+static void rename_switcher_finalize(GObject *object) {
+    G_OBJECT_CLASS(rename_switcher_parent_class)->finalize(object);
+}
+
+static void rename_switcher_class_init(RenameSwitcherClass *class) {
+    GObjectClass *object_class = G_OBJECT_CLASS(class);
+    object_class->dispose = rename_switcher_dispose;
+    object_class->finalize = rename_switcher_finalize;
+}
+
+static void rename_switcher_clear_search(RenameSwitcher *self) {
+    // clear search entry
+    gtk_editable_set_text(GTK_EDITABLE(SWITCHER(self).search_entry), "");
+}
+
+
+static void on_search_activated(GtkSearchEntry *entry, RenameSwitcher *self) {
+    // get search entry text
+    const gchar *search_text = gtk_editable_get_text(GTK_EDITABLE(entry));
+    if (strlen(search_text) == 0) return;
+
+    // switch to rename
+    WindowManager *wm = window_manager_service_get_global();
+    wm->rename_workspace(wm, search_text);
+
+    // hide widget
+    rename_switcher_hide(self);
+}
+
+static void on_search_stop(GtkSearchEntry *entry, RenameSwitcher *self) {
+    if (entry) {
+        const char *search_text = gtk_editable_get_text(GTK_EDITABLE(entry));
+        if (strlen(search_text) == 0) {
+            gtk_widget_set_visible(GTK_WIDGET(SWITCHER(self).win), false);
+            gtk_list_box_invalidate_filter(SWITCHER(self).list);
+            return;
+        }
+    }
+    rename_switcher_clear_search(self);
+}
+
+static gboolean key_pressed(GtkEventControllerKey *controller, guint keyval,
+                            guint keycode, GdkModifierType state,
+                            RenameSwitcher *self) {
+    return false;
+}
+
+static void rename_switcher_init_layout(RenameSwitcher *self) {
+    switcher_init(&self->switcher, false);
+
+    // wire into stop-search signal for GtkSearchEntry
+    g_signal_connect(SWITCHER(self).search_entry, "stop-search",
+                     G_CALLBACK(on_search_stop), self);
+
+    // wire into 'activate' signal
+    g_signal_connect(SWITCHER(self).search_entry, "activate",
+                     G_CALLBACK(on_search_activated), self);
+
+    // hook up keymap
+    g_signal_connect(SWITCHER(self).key_controller, "key-pressed",
+                     G_CALLBACK(key_pressed), self);
+}
+
+static void rename_switcher_init(RenameSwitcher *self) {
+    rename_switcher_init_layout(self);
+}
+
+RenameSwitcher *rename_switcher_get_global() { return global; }
+
+void rename_switcher_activate(AdwApplication *app, gpointer user_data) {
+    if (global == NULL) {
+        global = g_object_new(RENAME_SWITCHER_TYPE, NULL);
+    }
+}
+
+void rename_switcher_show(RenameSwitcher *self) {
+    g_debug("rename_switcher.c:rename_switcher_show() called.");
+
+    // grab search entry focus
+    gtk_widget_grab_focus(GTK_WIDGET(SWITCHER(self).search_entry));
+
+    gtk_window_present(GTK_WINDOW(SWITCHER(self).win));
+}
+
+void rename_switcher_hide(RenameSwitcher *self) {
+    g_debug("rename_switcher.c:rename_switcher_hide() called.");
+
+    on_search_stop(NULL, self);
+
+    gtk_widget_set_visible(GTK_WIDGET(SWITCHER(self).win), false);
+}
+
+void rename_switcher_toggle(RenameSwitcher *self) {
+    g_debug("rename_switcher.c:rename_switcher_toggle() called.");
+    if (gtk_widget_get_visible(GTK_WIDGET(SWITCHER(self).win))) {
+        rename_switcher_hide(self);
+    } else {
+        rename_switcher_show(self);
+    }
+}

--- a/src/rename_switcher/rename_switcher.h
+++ b/src/rename_switcher/rename_switcher.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+struct _RenameSwitcher;
+#define RENAME_SWITCHER_TYPE rename_switcher_get_type()
+G_DECLARE_FINAL_TYPE(RenameSwitcher, rename_switcher, Rename, Switcher,
+                     GObject);
+
+G_END_DECLS
+
+void rename_switcher_activate(AdwApplication *app, gpointer user_data);
+
+RenameSwitcher *rename_switcher_get_global();
+
+void rename_switcher_show(RenameSwitcher *self);
+
+void rename_switcher_hide(RenameSwitcher *self);
+
+void rename_switcher_toggle(RenameSwitcher *self);
+

--- a/src/services/ipc_service/ipc_commands.h
+++ b/src/services/ipc_service/ipc_commands.h
@@ -35,6 +35,9 @@ enum IPCCommands : uint32_t {
     IPC_CMD_BLUELIGHT_FILTER_DISABLE,
     IPC_CMD_KEYBOARD_BRIGHTNESS_UP,
     IPC_CMD_KEYBOARD_BRIGHTNESS_DOWN,
+    IPC_CMD_RENAME_SWITCHER_SHOW,
+    IPC_CMD_RENAME_SWITCHER_HIDE,
+    IPC_CMD_RENAME_SWITCHER_TOGGLE,
 };
 
 typedef struct _IPCHeader {
@@ -161,3 +164,15 @@ typedef struct _IPCKeyboardBrightnessUp {
 typedef struct _IPCKeyboardBrightnessDown {
     IPCHeader header;
 } IPCKeyboardBrightnessDown;
+
+typedef struct _IPCRenameSwitcherShow {
+	IPCHeader header;
+} IPCRenameSwitcherShow;
+
+typedef struct _IPCRenameSwitcherHide {
+	IPCHeader header;
+} IPCRenameSwitcherHide;
+
+typedef struct _IPCRenameSwitcherToggle {
+	IPCHeader header;
+} IPCRenameSwitcherToggle;

--- a/src/services/ipc_service/ipc_service.c
+++ b/src/services/ipc_service/ipc_service.c
@@ -8,6 +8,7 @@
 #include "../../activities/activities.h"
 #include "../../app_switcher/app_switcher.h"
 #include "../../output_switcher/output_switcher.h"
+#include "../../rename_switcher/rename_switcher.h"
 #include "../../panel/message_tray/message_tray.h"
 #include "../../services/brightness_service/brightness_service.h"
 #include "../../services/theme_service.h"
@@ -336,6 +337,45 @@ static gboolean ip_cmd_output_switcher_toggle() {
     }
 
     output_switcher_toggle(o);
+
+    return true;
+}
+
+static gboolean ip_cmd_rename_switcher_show() {
+    g_debug("ipc_service.c:ip_cmd_rename_switcher_show()");
+
+    RenameSwitcher *o = rename_switcher_get_global();
+    if (!o) {
+        return false;
+    }
+
+    rename_switcher_show(o);
+
+    return true;
+}
+
+static gboolean ip_cmd_rename_switcher_hide() {
+    g_debug("ipc_service.c:ip_cmd_rename_switcher_hide()");
+
+    RenameSwitcher *o = rename_switcher_get_global();
+    if (!o) {
+        return false;
+    }
+
+    rename_switcher_hide(o);
+
+    return true;
+}
+
+static gboolean ip_cmd_rename_switcher_toggle() {
+    g_debug("ipc_service.c:ip_cmd_rename_switcher_toggle()");
+
+    RenameSwitcher *o = rename_switcher_get_global();
+    if (!o) {
+        return false;
+    }
+
+    rename_switcher_toggle(o);
 
     return true;
 }
@@ -681,6 +721,24 @@ static gboolean on_ipc_readable(gint fd, GIOCondition condition,
                 "IPC_CMD_KEYBOARD_BRIGHTNESS_DOWN");
             ret = ipc_command_keyboard_brightness_down();
             break;
+		case IPC_CMD_RENAME_SWITCHER_SHOW:
+			g_debug(
+				"ipc_service.c:on_ipc_readable() received "
+				"IPC_CMD_RENAME_SWITCHER_SHOW");
+			ret = ip_cmd_rename_switcher_show();
+			break;
+		case IPC_CMD_RENAME_SWITCHER_HIDE:
+			g_debug(
+				"ipc_service.c:on_ipc_readable() received "
+				"IPC_CMD_RENAME_SWITCHER_HIDE");
+			ret = ip_cmd_rename_switcher_hide();
+			break;
+		case IPC_CMD_RENAME_SWITCHER_TOGGLE:
+			g_debug(
+				"ipc_service.c:on_ipc_readable() received "
+				"IPC_CMD_RENAME_SWITCHER_TOGGLE");
+			ret = ip_cmd_rename_switcher_toggle();
+			break;
         default:
             goto skip_resp;
             break;

--- a/src/services/window_manager_service/sway/sway_client.c
+++ b/src/services/window_manager_service/sway/sway_client.c
@@ -659,6 +659,22 @@ int sway_client_ipc_move_app_to_workspace(int socket_fd, gchar *workspace) {
     return sway_client_ipc_send(socket_fd, &msg);
 }
 
+int sway_client_ipc_rename_current_workspace(int socket_fd, const gchar *name) {
+    sway_client_ipc_msg msg = {.type = IPC_COMMAND};
+    char *cmd_prefix = "rename workspace to ";
+
+    if (!name) return -1;
+    if (strlen(name) == 0) return -1;
+
+    msg.size = strlen(cmd_prefix) + strlen(name) + 1;
+    msg.payload = g_malloc0(msg.size);
+
+    strcpy(msg.payload, cmd_prefix);
+    strcat(msg.payload, name);
+
+    return sway_client_ipc_send(socket_fd, &msg);
+}
+
 WMWorkspaceEvent *sway_client_ipc_event_workspace_resp(
     sway_client_ipc_msg *msg) {
     JsonParser *parser = NULL;

--- a/src/services/window_manager_service/sway/sway_client.h
+++ b/src/services/window_manager_service/sway/sway_client.h
@@ -94,6 +94,9 @@ int sway_client_ipc_move_ws_to_output(int socket_fd, gchar *output);
 // Move the current focused app to the provided workspace.
 int sway_client_ipc_move_app_to_workspace(int socket_fd, gchar *workspace);
 
+// Rename the current workspace to `name`
+int sway_client_ipc_rename_current_workspace(int socket_fd, const gchar *name);
+
 // Events //
 
 // Parses a workspace event and returns a WMWorkspaceEvent
@@ -107,4 +110,3 @@ int sway_client_ipc_move_app_to_workspace(int socket_fd, gchar *workspace);
 // in event.workspace may be nonsense.
 WMWorkspaceEvent *sway_client_ipc_event_workspace_resp(
     sway_client_ipc_msg *msg);
-

--- a/src/services/window_manager_service/sway/window_manager_service_sway.c
+++ b/src/services/window_manager_service/sway/window_manager_service_sway.c
@@ -2,6 +2,7 @@
 
 #include <adwaita.h>
 #include <glib-2.0/glib-unix.h>
+#include <string.h>
 
 #include "glib-object.h"
 #include "glib.h"
@@ -321,6 +322,15 @@ int wm_service_sway_focus_workspace(WindowManager *wm, WMWorkspace *ws) {
     return sway_client_ipc_focus_workspace(self->socket_fd, ws);
 }
 
+int wm_service_sway_rename_current_workspace(WindowManager *wm,
+                                             const gchar *name) {
+    WMServiceSway *self = wm->private;
+
+    if (strlen(name) == 0) return -1;
+
+    return sway_client_ipc_rename_current_workspace(self->socket_fd, name);
+}
+
 int wm_service_sway_current_ws_to_output(WindowManager *wm, WMOutput *o) {
     WMServiceSway *self = wm->private;
 
@@ -394,6 +404,7 @@ WindowManager *wm_service_sway_window_manager_init() {
     wm->get_workspaces = wm_service_sway_get_workspaces;
     wm->get_outputs = wm_service_sway_get_outputs;
     wm->focus_workspace = wm_service_sway_focus_workspace;
+    wm->rename_workspace = wm_service_sway_rename_current_workspace;
     wm->current_ws_to_output = wm_service_sway_current_ws_to_output;
     wm->current_app_to_workspace = wm_service_sway_current_app_to_workspace;
     wm->register_on_workspaces_changed =

--- a/src/services/window_manager_service/window_manager_service.h
+++ b/src/services/window_manager_service/window_manager_service.h
@@ -74,6 +74,9 @@ typedef GPtrArray *(*wm_get_outputs_func)(WindowManager *self);
 
 typedef int (*wm_focus_workspace_func)(WindowManager *self, WMWorkspace *ws);
 
+typedef int (*wm_rename_current_workspace_func)(WindowManager *self,
+                                                const gchar *name);
+
 typedef int (*wm_current_ws_to_output_func)(WindowManager *self, WMOutput *o);
 
 typedef int (*wm_current_app_to_workspace_func)(WindowManager *self,
@@ -108,6 +111,8 @@ typedef struct _WindowManager {
     wm_get_outputs_func get_outputs;
     // Focus the provided workspace
     wm_focus_workspace_func focus_workspace;
+    // Rename the current workspace
+    wm_rename_current_workspace_func rename_workspace;
     // Move the current workspace to the specified output
     wm_current_ws_to_output_func current_ws_to_output;
     // Move the current app to the specified workspace

--- a/src/switcher/switcher.c
+++ b/src/switcher/switcher.c
@@ -3,6 +3,8 @@
 #include <adwaita.h>
 #include <gtk4-layer-shell/gtk4-layer-shell.h>
 
+#include "gtk/gtk.h"
+
 void switcher_init(Switcher *self, gboolean has_list) {
     // create key controller
     self->key_controller = gtk_event_controller_key_new();
@@ -56,7 +58,10 @@ void switcher_init(Switcher *self, gboolean has_list) {
 
     // wire it up
     gtk_box_append(self->container, GTK_WIDGET(search_container));
-    if (has_list) gtk_box_append(self->container, GTK_WIDGET(self->scrolled));
+    if (has_list)
+        gtk_box_append(self->container, GTK_WIDGET(self->scrolled));
+    else
+        gtk_widget_add_css_class(GTK_WIDGET(self->container), "no_list");
 
     adw_window_set_content(self->win, GTK_WIDGET(self->container));
 }

--- a/way-sh/commands.h
+++ b/way-sh/commands.h
@@ -83,3 +83,8 @@ cmd_tree_node_t *workspace_app_switcher_cmd();
 //
 // Subcommands off this node deal with enabling and disabling the Night Light
 cmd_tree_node_t *bluelight_filter_cmd();
+
+// The Rename Switcher command
+//
+// Subcommands off this node deal with showing and hiding the Rename Switcher
+cmd_tree_node_t *rename_switcher_cmd();

--- a/way-sh/main.c
+++ b/way-sh/main.c
@@ -52,6 +52,7 @@ static void build_command_tree() {
     cmd_tree_node_t *workspace_app_switcher = workspace_app_switcher_cmd();
     cmd_tree_node_t *output_switcher = output_switcher_cmd();
     cmd_tree_node_t *bluelight_filter = bluelight_filter_cmd();
+	cmd_tree_node_t *rename_switcher = rename_switcher_cmd();
 
     cmd_tree_node_add_child(&root_cmd, message_tray);
     cmd_tree_node_add_child(&root_cmd, volume);
@@ -63,6 +64,7 @@ static void build_command_tree() {
     cmd_tree_node_add_child(&root_cmd, workspace_app_switcher);
     cmd_tree_node_add_child(&root_cmd, output_switcher);
     cmd_tree_node_add_child(&root_cmd, bluelight_filter);
+	cmd_tree_node_add_child(&root_cmd, rename_switcher);
 }
 
 int main(int argc, char **argv) {

--- a/way-sh/rename_switcher_cmd.c
+++ b/way-sh/rename_switcher_cmd.c
@@ -1,0 +1,97 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "../lib/cmd_tree/include/cmd_tree.h"
+#include "../src/services/ipc_service/ipc_commands.h"
+#include "commands.h"
+
+static int rename_switcher_exec(void *ctx, uint8_t argc, char **argv) {
+    printf(
+        "Summary:\n"
+        "\tManipulate the RenameSwitcher widget.\n"
+        "Commands:\n"
+        "\tshow   - show the RenameSwitcher widget\n"
+        "\thide   - hide the RenameSwitcher widget\n"
+        "\ttoggle - toggle the RenameSwitcher widget");
+    return 0;
+};
+
+cmd_tree_node_t rename_switcher_root = {.name = "rename-switcher",
+                                     .exec = rename_switcher_exec};
+
+static int rename_switcher_show_exec(void *ctx, uint8_t argc, char **argv) {
+    int ret = 0;
+    way_sh_ctx *way_ctx = ctx;
+
+    IPCRenameSwitcherShow msg = {.header.type = IPC_CMD_RENAME_SWITCHER_SHOW};
+
+    IPC_SEND_MSG(way_ctx, msg);
+
+    if (ret == -1) {
+        perror("[Error] Failed to send IPCRenameSwitcherShow");
+        return -1;
+    }
+
+    bool response = false;
+    IPC_RECV_MSG(way_ctx, addr, &response);
+
+    return response;
+};
+
+cmd_tree_node_t rename_switcher_show_cmd = {.name = "show",
+                                         .exec = rename_switcher_show_exec};
+
+static int rename_switcher_hide_exec(void *ctx, uint8_t argc, char **argv) {
+    int ret = 0;
+    way_sh_ctx *way_ctx = ctx;
+
+    IPCRenameSwitcherHide msg = {.header.type = IPC_CMD_RENAME_SWITCHER_HIDE};
+
+    IPC_SEND_MSG(way_ctx, msg);
+
+    if (ret == -1) {
+        perror("[Error] Failed to send IPCRenameSwitcherHide");
+        return -1;
+    }
+
+    bool response = false;
+    IPC_RECV_MSG(way_ctx, addr, &response);
+
+    return response;
+};
+
+cmd_tree_node_t rename_switcher_hide_cmd = {.name = "hide",
+                                         .exec = rename_switcher_hide_exec};
+
+static int rename_switcher_toggle_exec(void *ctx, uint8_t argc, char **argv) {
+    int ret = 0;
+    way_sh_ctx *way_ctx = ctx;
+
+    IPCRenameSwitcherToggle msg = {.header.type = IPC_CMD_RENAME_SWITCHER_TOGGLE};
+
+    IPC_SEND_MSG(way_ctx, msg);
+
+    if (ret == -1) {
+        perror("[Error] Failed to send IPCRenameSwitcherToggle");
+        return -1;
+    }
+
+    bool response = false;
+    IPC_RECV_MSG(way_ctx, addr, &response);
+
+    return response;
+};
+
+cmd_tree_node_t rename_switcher_toggle_cmd = {.name = "toggle",
+                                           .exec = rename_switcher_toggle_exec};
+
+cmd_tree_node_t *rename_switcher_cmd() {
+    cmd_tree_node_add_child(&rename_switcher_root, &rename_switcher_show_cmd);
+    cmd_tree_node_add_child(&rename_switcher_root, &rename_switcher_hide_cmd);
+    cmd_tree_node_add_child(&rename_switcher_root, &rename_switcher_toggle_cmd);
+
+    return &rename_switcher_root;
+};

--- a/way-sh/root.c
+++ b/way-sh/root.c
@@ -17,6 +17,7 @@ static int root_exec(void *ctx, uint8_t argc, char **argv) {
         "\tworkspace-app-switcher\n"
         "\toutput-switcher\n"
 		"\tbluelight-filter\n"
+		"\trename-switcher\n"
 	);
     return 0;
 };


### PR DESCRIPTION
A new widget for renaming a workspace is introduced.

Use `way-sh` to display the widget.

The widget is a simple input box which takes text, the new name for the currently active workspace.