### PR TITLE
change some top layer things to overlay layer

### DIFF
--- a/src/app_switcher/app_switcher.c
+++ b/src/app_switcher/app_switcher.c
@@ -202,7 +202,7 @@ static void app_switcher_init_layout(AppSwitcher *self) {
     // configure layershell, no anchors will place window in center.
     gtk_layer_init_for_window(GTK_WINDOW(self->win));
     gtk_layer_set_namespace(GTK_WINDOW(self->win), "way-shell-switcher");
-    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_TOP);
+    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_OVERLAY);
     gtk_layer_set_anchor((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,
                          true);
     gtk_layer_set_margin((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,

--- a/src/app_switcher/app_switcher_app_widget.c
+++ b/src/app_switcher/app_switcher_app_widget.c
@@ -115,7 +115,7 @@ static void app_switcher_app_widget_init_layout(AppSwitcherAppWidget *self) {
     // configure layershell, no anchors will place window in center.
     gtk_layer_init_for_window(GTK_WINDOW(self->win));
     gtk_layer_set_namespace(GTK_WINDOW(self->win), "way-shell-switcher");
-    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_TOP);
+    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_OVERLAY);
     gtk_layer_set_anchor((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,
                          true);
     gtk_layer_set_margin((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -257,7 +257,7 @@ void osd_init_layout(OSD *self) {
     // configure layershell, top layer and center
     gtk_layer_init_for_window(GTK_WINDOW(self->win));
     gtk_layer_set_namespace(GTK_WINDOW(self->win), "way-shell-osd");
-    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_TOP);
+    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_OVERLAY);
     gtk_widget_set_name(GTK_WIDGET(self->win), "osd");
     gtk_layer_set_anchor(GTK_WINDOW(self->win), GTK_LAYER_SHELL_EDGE_BOTTOM,
                          true);

--- a/src/switcher/switcher.c
+++ b/src/switcher/switcher.c
@@ -20,7 +20,7 @@ void switcher_init(Switcher *self, gboolean has_list) {
     // configure layershell, no anchors will place window in center.
     gtk_layer_init_for_window(GTK_WINDOW(self->win));
     gtk_layer_set_namespace(GTK_WINDOW(self->win), "way-shell-switcher");
-    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_TOP);
+    gtk_layer_set_layer((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_LAYER_OVERLAY);
     gtk_layer_set_anchor((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,
                          true);
     gtk_layer_set_margin((GTK_WINDOW(self->win)), GTK_LAYER_SHELL_EDGE_TOP,


### PR DESCRIPTION
Now we can see these things over fullscreen windows. I've changed only the uncontroversial ones (I think!); e.g. I prefer notifications to be on overlay but it's configurable in plasma so it's left alone here for now.

I want to change activities to be on overlay as well, but that needs the panel to be in overlay iff activities is open, which is going to be a bigger patch. Otherwise, with activities open over a fullscreen window, there is a hole at the top where the panel should be.