### PR TITLE
Allow to run on_theme_changed without '.sh' extention

### DIFF
--- a/src/services/theme_service.c
+++ b/src/services/theme_service.c
@@ -46,18 +46,21 @@ static void on_theme_switch(ThemeService *self) {
         arg = "dark";
     }
 
-    // check if {config_dir}/way-shell/on_theme_changed.sh file exists
+    // check if {config_dir}/way-shell/on_theme_changed{.sh} file exists
     // if it does, execute it with
-    char *script_path =
-        g_build_filename(conf_dir, CONFIG_DIR, "on_theme_changed.sh", NULL);
-    if (g_file_test(script_path,
-                    G_FILE_TEST_EXISTS | G_FILE_TEST_IS_EXECUTABLE)) {
-        char *cmd = g_strdup_printf("bash -c '%s %s'", script_path, arg);
-        GError *error = NULL;
-        g_spawn_command_line_async(cmd, &error);
-        if (error != NULL) {
-            g_warning("Failed to execute command: %s", error->message);
-            g_error_free(error);
+    char *scripts_path[2];
+    scripts_path[0] = g_build_filename(conf_dir, CONFIG_DIR, "on_theme_changed", NULL);
+    scripts_path[1] = g_build_filename(conf_dir, CONFIG_DIR, "on_theme_changed.sh", NULL);
+    for (size_t i = 0; i < 2; ++i) {
+        if (g_file_test(scripts_path[i], G_FILE_TEST_EXISTS | G_FILE_TEST_IS_EXECUTABLE)) {
+            char *cmd = g_strdup_printf("%s %s", scripts_path[i], arg);
+            GError *error = NULL;
+            g_spawn_command_line_async(cmd, &error);
+            if (error != NULL) {
+                g_warning("Failed to execute command: %s", error->message);
+                g_error_free(error);
+            }
+	    break;
         }
     }
 }


### PR DESCRIPTION
Hi, I'm very interested in this project and this is to test the waters.

The idea here is to make the user aware that the `on_theme_changed` program can be written I any language, so now way-shell search both for `on_theme_changed` and `on_theme_changed.sh`.