### PR TITLE
notifications: support actions and add hide on OSD

### DIFF
--- a/data/theme/way-shell-dark.css
+++ b/data/theme/way-shell-dark.css
@@ -464,6 +464,43 @@ label.day-number.today:focus {
     margin: 2px;
 }
 
+#notifications-osd .notification-widget-action-button,
+#notifications-list .notification-widget-action-button {
+	border-radius: 0px;
+	margin: 0px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	font-size: 14px;
+}
+
+#notifications-osd .notification-widget-action-button.only,
+#notifications-list .notification-widget-action-button.only {
+	border-bottom-left-radius: 8px;
+	border-bottom-right-radius: 8px;
+}
+
+#notifications-osd .notification-widget-action-button.first,
+#notifications-list .notification-widget-action-button.first {
+	border-bottom-left-radius: 8px;
+	border-right: .25px solid;
+}
+
+#notifications-osd .notification-widget-action-button.center,
+#notifications-list .notification-widget-action-button.center {
+	border-bottom-left-radius: 0px;
+	border-right: .25px solid;
+}
+
+#notifications-osd .notification-widget-action-button.last,
+#notifications-list .notification-widget-action-button.last {
+	border-bottom-right-radius: 8px;
+}
+
+#notifications-osd .notification-widget-action-button:hover,
+#notifications-list .notification-widget-action-button:hover {
+    background: @panel-button-hover;
+}
+
 #notifications-list #notifications-list-controls {
   font-weight: bold;
   font-size: 14px;

--- a/data/theme/way-shell-light.css
+++ b/data/theme/way-shell-light.css
@@ -467,6 +467,43 @@ statuspage {
     margin: 2px;
 }
 
+#notifications-osd .notification-widget-action-button,
+#notifications-list .notification-widget-action-button {
+	border-radius: 0px;
+	margin: 0px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	font-size: 14px;
+}
+
+#notifications-osd .notification-widget-action-button.only,
+#notifications-list .notification-widget-action-button.only {
+	border-bottom-left-radius: 8px;
+	border-bottom-right-radius: 8px;
+}
+
+#notifications-osd .notification-widget-action-button.first,
+#notifications-list .notification-widget-action-button.first {
+	border-bottom-left-radius: 8px;
+	border-right: .25px solid;
+}
+
+#notifications-osd .notification-widget-action-button.center,
+#notifications-list .notification-widget-action-button.center {
+	border-bottom-left-radius: 0px;
+	border-right: .25px solid;
+}
+
+#notifications-osd .notification-widget-action-button.last,
+#notifications-list .notification-widget-action-button.last {
+	border-bottom-right-radius: 8px;
+}
+
+#notifications-osd .notification-widget-action-button:hover,
+#notifications-list .notification-widget-action-button:hover {
+    background: @panel-button-hover;
+}
+
 #notifications-list #notifications-list-controls {
   font-weight: bold;
   font-size: 14px;

--- a/src/panel/message_tray/notifications/notification_osd.c
+++ b/src/panel/message_tray/notifications/notification_osd.c
@@ -153,6 +153,8 @@ static void on_notification_added(NotificationsService *ns,
     }
 
     NotificationWidget *new = notification_widget_from_notification(n, true);
+	notification_widget_set_osd(new, self);
+
     // for some reason, we need to reset this before presenting, despite
     // them being set in the constructing function.
     GtkLabel *summary = notification_widget_get_summary(new);
@@ -252,4 +254,15 @@ static void notifications_osd_init(NotificationsOSD *self) {
 void notification_osd_set_notification_list(NotificationsOSD *self,
                                             NotificationsList *list) {
     self->list = list;
+}
+
+void notification_osd_hide(NotificationsOSD *self) {
+    if (!self->win) return;
+    gtk_revealer_set_reveal_child(self->revealer, false);
+
+    // if timer, kill is
+    if (self->timeout_id) {
+        g_source_remove(self->timeout_id);
+        self->timeout_id = 0;
+    }
 }

--- a/src/panel/message_tray/notifications/notification_osd.h
+++ b/src/panel/message_tray/notifications/notification_osd.h
@@ -2,7 +2,6 @@
 
 #include <adwaita.h>
 
-#include "./notification_widget.h"
 #include "./notifications_list.h"
 
 G_BEGIN_DECLS
@@ -18,3 +17,5 @@ void notification_osd_reinitialize(NotificationsOSD *self);
 
 void notification_osd_set_notification_list(NotificationsOSD *self,
                                             NotificationsList *list);
+
+void notification_osd_hide(NotificationsOSD *self);

--- a/src/panel/message_tray/notifications/notification_widget.h
+++ b/src/panel/message_tray/notifications/notification_widget.h
@@ -4,6 +4,7 @@
 
 #include "../../../services/media_player_service/media_player_service.h"
 #include "../../../services/notifications_service/notifications_service.h"
+#include "notification_osd.h"
 
 G_BEGIN_DECLS
 
@@ -36,3 +37,12 @@ void notification_widget_set_stack_effect(NotificationWidget *self,
 void notification_widget_dismiss_notification(NotificationWidget *self);
 
 gchar *notification_widget_get_media_player_name(NotificationWidget *self);
+
+// If the NotificationWidget is associated with an Notification on screen
+// display, this method will set a synthetic 'Hide' action button which
+// closes the OSD.
+void notification_widget_set_osd(NotificationWidget *self,
+                                 NotificationsOSD *osd);
+
+NotificationsOSD *notification_widget_get_osd(NotificationWidget *self);
+

--- a/src/services/notifications_service/notifications_service.c
+++ b/src/services/notifications_service/notifications_service.c
@@ -241,7 +241,10 @@ static gboolean on_handle_notify(DbusNotifications *dbus,
     // parse hints
     parse_notify_hints(hints, n);
 
-    n->id = self->last_id++;
+	// ids should start at zero for client compat
+    n->id = self->last_id;
+    self->last_id++;
+
     n->replaces_id = replaces_id;
     n->expire_timeout = expire_timeout;
     n->created_on = g_date_time_new_now_local();
@@ -354,6 +357,7 @@ static void notifications_service_init(NotificationsService *self) {
     g_debug("notifications_service.c:notifications_service_init() called");
 
     self->enabled = false;
+    self->last_id = 0;
 
     notifications_service_dbus_connect(self);
 


### PR DESCRIPTION
Implement Gnome 46 style action buttons on events.

Additionally, add a Way-Shell specific button to hide a notification when its displayed as an OSD.

A hiden notification is simply removed from the on screen display but still resides in the NotificationList for later action.

add hide button for osd