### PR TITLE
fix,wifi: allow connecting to WPA AP's with no password

### DIFF
--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_wifi/quick_settings_grid_wifi_menu_option.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_wifi/quick_settings_grid_wifi_menu_option.c
@@ -198,11 +198,11 @@ void quick_settings_grid_wifi_menu_option_update_ap(
     NMAccessPoint *ap) {
     NMDeviceState state = nm_device_get_state(NM_DEVICE(dev));
     gboolean is_active_ap = nm_device_wifi_get_active_access_point(dev) == ap;
-    if ((nm_access_point_get_flags(ap) == NM_802_11_AP_FLAGS_NONE)) {
-        self->has_sec = false;
-    } else {
+
+    self->has_sec = false;
+    if (nm_access_point_get_wpa_flags(ap) != NM_802_11_AP_SEC_NONE ||
+        nm_access_point_get_rsn_flags(ap) != NM_802_11_AP_SEC_NONE)
         self->has_sec = true;
-    }
 
     if (is_active_ap) {
         // unhide spinner and start it


### PR DESCRIPTION
Prior to this commit there was a misunderstanding in how to identity WIFI APs without password protection.

The nm_access_point_get_wpa_flags and nm_access_point_get_rsn_flags should be used instead of the general nm_access_point_get_flags flags.

This is because an AP can still advertise WPA abilities without having a password enabled.

We actually don't care too much about the 'general' abilities of an AP, so just check the security related flags.