### PR TITLE
refactor: use overlay for quick settings grid buttons

### DIFF
--- a/data/theme/way-shell-dark.css
+++ b/data/theme/way-shell-dark.css
@@ -643,14 +643,9 @@ label.day-number.today:focus {
 }
 
 #quick-settings .quick-settings-grid-button-toggle {
-  border-top-left-radius: 99px;
-  border-bottom-left-radius: 99px;
+  border-radius: 99px;
   background-color: @quick-settings-button;
   padding: 2px;
-}
-
-#quick-settings .quick-settings-grid-button-toggle.no-revealer {
-  border-radius: 99px;
 }
 
 #quick-settings .quick-settings-grid-button-toggle.off {

--- a/data/theme/way-shell-light.css
+++ b/data/theme/way-shell-light.css
@@ -690,14 +690,9 @@ statuspage {
 }
 
 #quick-settings .quick-settings-grid-button-toggle {
-  border-top-left-radius: 99px;
-  border-bottom-left-radius: 99px;
+  border-radius: 99px;
   background-color: @quick-settings-button;
   padding: 2px;
-}
-
-#quick-settings .quick-settings-grid-button-toggle.no-revealer {
-  border-radius: 99px;
 }
 
 #quick-settings .quick-settings-grid-button-toggle.off {

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid.c
@@ -156,9 +156,6 @@ static void quick_settings_grid_add_button(QuickSettingsGrid *self,
     // the cluster owns this button now, will notify us when it is removed,
     // and will clean the button's memory.
     quick_settings_grid_cluster_add_button(cluster, side, button);
-
-    // adjust button sizes.
-    quick_settings_grid_cluster_realize_size(cluster);
 }
 
 static void on_network_manager_change(NetworkManagerService *nm,

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_button.c
@@ -11,6 +11,7 @@
 #include "./quick_settings_grid_vpn/quick_settings_grid_vpn.h"
 #include "./quick_settings_grid_wifi/quick_settings_grid_wifi.h"
 #include "./quick_settings_keyboard_brightness/quick_settings_grid_keyboard_brightness.h"
+#include "gtk/gtk.h"
 #include "gtk/gtkrevealer.h"
 #include "quick_settings_grid_ethernet.h"
 
@@ -63,9 +64,13 @@ void quick_settings_grid_button_init(
     // append pointer to self on container's data
     g_object_set_data(G_OBJECT(self->toggle), "self", self);
 
+    GtkOverlay *overlay = GTK_OVERLAY(gtk_overlay_new());
+    gtk_overlay_set_child(overlay, GTK_WIDGET(self->toggle));
+
     // GtkCenterBox *center_box = GTK_CENTER_BOX(gtk_center_box_new());
     GtkBox *button_contents =
         GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+
     // valign center
     gtk_widget_set_valign(GTK_WIDGET(button_contents), GTK_ALIGN_CENTER);
     // create and append icon
@@ -112,7 +117,7 @@ void quick_settings_grid_button_init(
     }
     gtk_box_append(button_contents, GTK_WIDGET(text_area));
     gtk_button_set_child(self->toggle, GTK_WIDGET(button_contents));
-    gtk_box_append(self->container, GTK_WIDGET(self->toggle));
+    gtk_box_append(self->container, GTK_WIDGET(overlay));
 
     // setup revealer
     self->revealer = GTK_REVEALER(gtk_revealer_new());
@@ -130,7 +135,9 @@ void quick_settings_grid_button_init(
         gtk_widget_add_css_class(GTK_WIDGET(self->reveal_button),
                                  "quick-settings-grid-button-reveal-hidden");
 
-        gtk_box_append(self->container, GTK_WIDGET(self->reveal_button));
+        gtk_widget_set_halign(GTK_WIDGET(self->reveal_button), GTK_ALIGN_END);
+
+        gtk_overlay_add_overlay(overlay, GTK_WIDGET(self->reveal_button));
 
         // add reveal_widget as child of revealer
         gtk_revealer_set_child(self->revealer, self->reveal_widget);
@@ -142,9 +149,6 @@ void quick_settings_grid_button_init(
 
         gtk_widget_add_css_class(GTK_WIDGET(self->reveal_button),
                                  "quick-settings-grid-button-reveal-visible");
-    } else {
-        // add no-revealer class to toggle button
-        gtk_widget_add_css_class(GTK_WIDGET(self->toggle), "no-revealer");
     }
 }
 

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_cluster.c
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_cluster.c
@@ -125,28 +125,6 @@ static void on_will_reveal(QuickSettingsGridCluster *self,
     }
 }
 
-
-// Total hack, but this ensures that buttons without a revealer button take up
-// just as much space as buttons with a revealer button.
-//
-// This is necessary since the buttons with a reveal button request more space
-// in the GtkCenterBox of the grid cluster and thus make buttons without a
-// reveal button smaller in size.
-void quick_settings_grid_cluster_realize_size(
-    QuickSettingsGridCluster *self) {
-    QuickSettingsGridButton *left = self->left;
-    QuickSettingsGridButton *right = self->right;
-
-    if (!left->reveal_widget) {
-        if (self->right && self->right->reveal_widget)
-            gtk_widget_set_size_request(GTK_WIDGET(left->container), 182, -1);
-    }
-    if (!right->reveal_widget) {
-        if (self->left && self->left->reveal_widget)
-            gtk_widget_set_size_request(GTK_WIDGET(right->container), 182, -1);
-    }
-}
-
 int quick_settings_grid_cluster_add_button(
     QuickSettingsGridCluster *self, enum QuickSettingsGridClusterSide side,
     QuickSettingsGridButton *button) {

--- a/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_cluster.h
+++ b/src/panel/quick_settings/quick_settings_grid/quick_settings_grid_cluster.h
@@ -61,5 +61,3 @@ QuickSettingsGridButton *quick_settings_grid_cluster_get_left_button(
 
 QuickSettingsGridButton *quick_settings_grid_cluster_get_right_button(
     QuickSettingsGridCluster *self);
-
-void quick_settings_grid_cluster_realize_size(QuickSettingsGridCluster *self);


### PR DESCRIPTION
This commit moves to using an overlay to display the reveal button ontop of the toggle buttons in the quick settings grid.

This makes spacing of the buttons way more predictable and the grid remains even depsite a mix of toggle buttons with and without reveal buttons.