### PR TITLE
feat,upower: add battery power menu

### DIFF
--- a/data/theme/way-shell-dark.css
+++ b/data/theme/way-shell-dark.css
@@ -593,6 +593,22 @@ label.day-number.today:focus {
   padding: 5px 10px;
 }
 
+#quick-settings #quick-settings-header.#battery-menu scale slider {
+	background: @transparent
+}
+#quick-settings #quick-settings-header.#battery-menu scale highlight {
+	background: shade(@success, 2);
+}
+#quick-settings #quick-settings-header.#battery-menu label {
+	padding: 0px;
+	margin-left: 12px;
+	margin-right: 12px;
+	margin-top: 2px;
+	margin-bottom: 4px;
+	font-weight: bold;
+	color: @panel-button-color;
+}
+
 #quick-settings #quick-settings-header image,
 #quick-settings #quick-settings-header label {
   padding: 2px;

--- a/data/theme/way-shell-light.css
+++ b/data/theme/way-shell-light.css
@@ -640,6 +640,22 @@ statuspage {
   padding: 5px 10px;
 }
 
+#quick-settings #quick-settings-header.#battery-menu scale slider {
+	background: @transparent
+}
+#quick-settings #quick-settings-header.#battery-menu scale highlight {
+	background: shade(@success, 2);
+}
+#quick-settings #quick-settings-header.#battery-menu label {
+	padding: 0px;
+	margin-left: 12px;
+	margin-right: 12px;
+	margin-top: 2px;
+	margin-bottom: 4px;
+	font-weight: bold;
+	color: @panel-button-color;
+}
+
 #quick-settings #quick-settings-header image,
 #quick-settings #quick-settings-header label {
   padding: 2px;

--- a/src/panel/quick_settings/quick_settings_header/quick_settings_battery_button.c
+++ b/src/panel/quick_settings/quick_settings_header/quick_settings_battery_button.c
@@ -193,9 +193,14 @@ void quick_settings_battery_button_reinitialize(
     // kill signals
     g_signal_handlers_disconnect_by_func(self->device,
                                          G_CALLBACK(on_power_dev_notify), self);
-    // un ref powre device
+    // un ref power device
     g_object_unref(self->device);
 
     // init our layout
     quick_settings_battery_button_init_layout(self);
+}
+
+GtkButton *quick_settings_battery_button_get_button(
+    QuickSettingsBatteryButton *self) {
+	return self->button;
 }

--- a/src/panel/quick_settings/quick_settings_header/quick_settings_battery_button.h
+++ b/src/panel/quick_settings/quick_settings_header/quick_settings_battery_button.h
@@ -17,3 +17,6 @@ void quick_settings_battery_button_reinitialize(
 
 GtkWidget *quick_settings_battery_button_get_widget(
     QuickSettingsBatteryButton *self);
+
+GtkButton *quick_settings_battery_button_get_button(
+    QuickSettingsBatteryButton *self);

--- a/src/panel/quick_settings/quick_settings_header/quick_settings_battery_menu.c
+++ b/src/panel/quick_settings/quick_settings_header/quick_settings_battery_menu.c
@@ -1,0 +1,193 @@
+#include "quick_settings_battery_menu.h"
+
+#include <adwaita.h>
+
+#include "../../../services/upower_service.h"
+#include "../quick_settings.h"
+#include "../quick_settings_menu_widget.h"
+#include "gtk/gtk.h"
+
+enum signals { signals_n };
+
+typedef struct _QuickSettingsBatteryMenu {
+    QuickSettingsMenuWidget menu;
+    GtkScale *battery_scale;
+    GtkLabel *battery_time;
+    GSettings *settings;
+} QuickSettingsBatteryMenu;
+G_DEFINE_TYPE(QuickSettingsBatteryMenu, quick_settings_battery_menu,
+              G_TYPE_OBJECT);
+
+static void on_power_dev_notify(UpDevice *power_dev, GParamSpec *pspec,
+                                QuickSettingsBatteryMenu *self) {
+    g_debug("quick_settings_battery_button.c:on_power_dev_notify() called.");
+
+    gchar *icon_name = upower_device_map_icon_name(power_dev);
+    gtk_menu_button_set_icon_name(GTK_MENU_BUTTON(self->menu.icon), icon_name);
+
+    gboolean is_recharable = false;
+    g_object_get(power_dev, "is-rechargeable", &is_recharable, NULL);
+    if (!is_recharable) {
+        gtk_range_set_value(GTK_RANGE(self->battery_scale), 100);
+        gtk_label_set_text(self->battery_time, "");
+    }
+
+    double percent = 0;
+    guint state = 0;
+    g_object_get(power_dev, "percentage", &percent, NULL);
+    g_object_get(power_dev, "state", &state, NULL);
+
+    // update battery scale
+    gtk_range_set_value(GTK_RANGE(self->battery_scale), percent);
+
+    gboolean charging = (state == UP_DEVICE_STATE_CHARGING ||
+                         state == UP_DEVICE_STATE_FULLY_CHARGED ||
+                         state == UP_DEVICE_STATE_PENDING_CHARGE);
+
+    gchar *time_str = NULL;
+    if (charging) {
+        gint64 time_to_full = 0;
+        g_object_get(power_dev, "time-to-full", &time_to_full, NULL);
+
+        gint64 days = time_to_full / (60 * 60 * 24);
+        gint64 hours = (time_to_full / (60 * 60)) % 24;
+        gint64 minutes = (time_to_full / 60) % 60;
+
+        if (days) {
+            time_str =
+                g_strdup_printf("%ld Days %ld Hours %ld Minutes Until Charged",
+                                days, hours, minutes);
+        } else if (hours) {
+            time_str = g_strdup_printf("%ld Hours %ld Minutes Until Charged",
+                                       hours, minutes);
+        } else {
+            time_str = g_strdup_printf("%ld Minutes Until Charged", minutes);
+        }
+    } else {
+        gint64 time_to_empty = 0;
+        g_object_get(power_dev, "time-to-empty", &time_to_empty, NULL);
+
+        gint64 days = time_to_empty / (60 * 60 * 24);
+        gint64 hours = (time_to_empty / (60 * 60)) % 24;
+        gint64 minutes = (time_to_empty / 60) % 60;
+
+        if (days) {
+            time_str =
+                g_strdup_printf("%ld Days %ld Hours %ld Minutes Remaining",
+                                days, hours, minutes);
+        } else if (hours) {
+            time_str = g_strdup_printf("%ld Hours %ld Minutes Remaining", hours,
+                                       minutes);
+        } else {
+            time_str = g_strdup_printf("%ld Minutes Remaining", minutes);
+        }
+    }
+
+    gtk_label_set_text(self->battery_time, time_str);
+    g_free(time_str);
+}
+
+static void on_quick_settings_hidden(QuickSettings *qs,
+                                     QuickSettingsBatteryMenu *self) {
+    g_debug("quick_settings_battery_menu.c:on_quick_settings_hidden() called.");
+}
+
+// stub out empty dispose, finalize, class_init, and init methods for this
+// GObject.
+static void quick_settings_battery_menu_dispose(GObject *gobject) {
+    g_debug(
+        "quick_settings_battery_menu.c:quick_settings_battery_menu_dispose() "
+        "called.");
+
+    // kill signals
+    QuickSettings *qs = quick_settings_get_global();
+    g_signal_handlers_disconnect_by_func(qs, on_quick_settings_hidden, gobject);
+
+    UPowerService *upower = upower_service_get_global();
+    UpDevice *power_dev = upower_service_get_primary_device(upower);
+    g_signal_handlers_disconnect_by_func(power_dev, on_power_dev_notify,
+                                         gobject);
+
+    // Chain-up
+    G_OBJECT_CLASS(quick_settings_battery_menu_parent_class)->dispose(gobject);
+};
+
+static void quick_settings_battery_menu_finalize(GObject *gobject) {
+    // Chain-up
+    G_OBJECT_CLASS(quick_settings_battery_menu_parent_class)->finalize(gobject);
+};
+
+static void quick_settings_battery_menu_class_init(
+    QuickSettingsBatteryMenuClass *klass) {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->dispose = quick_settings_battery_menu_dispose;
+    object_class->finalize = quick_settings_battery_menu_finalize;
+};
+
+static void quick_settings_battery_menu_init_layout(
+    QuickSettingsBatteryMenu *self) {
+    g_debug(
+        "quick_settings_battery_menu.c:quick_settings_battery_menu_init() "
+        "called.");
+
+    quick_settings_menu_widget_init(&self->menu, false);
+    quick_settings_menu_widget_set_title(&self->menu, "Battery");
+    quick_settings_menu_widget_set_icon(&self->menu, "battery-full-symbolic");
+
+    GtkBox *container = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+    gtk_widget_set_name(GTK_WIDGET(container), "battery-menu");
+    GtkCenterBox *center_box = GTK_CENTER_BOX(gtk_center_box_new());
+
+    self->battery_scale = GTK_SCALE(
+        gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 0, 100, 1));
+    // do not allow interacting with the scale
+    gtk_widget_set_sensitive(GTK_WIDGET(self->battery_scale), FALSE);
+	gtk_scale_set_draw_value(self->battery_scale, true);
+	gtk_scale_set_value_pos(self->battery_scale, GTK_POS_TOP);
+
+    self->battery_time = GTK_LABEL(gtk_label_new(""));
+	gtk_label_set_ellipsize(self->battery_time, PANGO_ELLIPSIZE_END);
+
+    gtk_box_append(container, GTK_WIDGET(self->battery_scale));
+    gtk_center_box_set_center_widget(center_box, GTK_WIDGET(self->battery_time));
+    gtk_box_append(container, GTK_WIDGET(center_box));
+
+    gtk_box_append(self->menu.options, GTK_WIDGET(container));
+
+    UPowerService *upower = upower_service_get_global();
+
+    // get primary power device
+    UpDevice *power_dev = upower_service_get_primary_device(upower);
+
+	on_power_dev_notify(power_dev, NULL, self);
+
+    g_signal_connect(power_dev, "notify", G_CALLBACK(on_power_dev_notify),
+                     self);
+
+    // wire into quick settings hidden event and close all revealers
+    QuickSettings *qs = quick_settings_get_global();
+    g_signal_connect(qs, "quick-settings-hidden",
+                     G_CALLBACK(on_quick_settings_hidden), self);
+}
+
+void quick_settings_battery_menu_reinitialize(QuickSettingsBatteryMenu *self) {
+    // kill signals to quick settings mediator
+    QuickSettings *qs = quick_settings_get_global();
+    g_signal_handlers_disconnect_by_func(qs, on_quick_settings_hidden, self);
+
+    // kill signals to power device
+    UPowerService *upower = upower_service_get_global();
+    UpDevice *power_dev = upower_service_get_primary_device(upower);
+    g_signal_handlers_disconnect_by_func(power_dev, on_power_dev_notify, self);
+
+    quick_settings_battery_menu_init_layout(self);
+}
+
+static void quick_settings_battery_menu_init(QuickSettingsBatteryMenu *self) {
+    quick_settings_battery_menu_init_layout(self);
+}
+
+GtkWidget *quick_settings_battery_menu_get_widget(
+    QuickSettingsBatteryMenu *self) {
+    return GTK_WIDGET(self->menu.container);
+}

--- a/src/panel/quick_settings/quick_settings_header/quick_settings_battery_menu.h
+++ b/src/panel/quick_settings/quick_settings_header/quick_settings_battery_menu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+struct _QuickSettingsBatteryMenu;
+#define QUICK_SETTINGS_BATTERY_MENU_TYPE quick_settings_battery_menu_get_type()
+G_DECLARE_FINAL_TYPE(QuickSettingsBatteryMenu, quick_settings_battery_menu,
+                     QUICK_SETTINGS, BATTERY_MENU, GObject);
+
+G_END_DECLS
+
+// Called to reinitialize the widget without allocating a new one.
+void quick_settings_battery_menu_reinitialize(QuickSettingsBatteryMenu *self);
+
+GtkWidget *quick_settings_battery_menu_get_widget(QuickSettingsBatteryMenu *self);


### PR DESCRIPTION
Add a battery power menu which shows the remaining time estimation till empty and full.

Looks like this:
![image](https://github.com/user-attachments/assets/b04fc46a-807b-4b38-8813-71e932caa779)

