### PR TITLE
app-switcher: use tilde for moving between app instances

### DIFF
--- a/src/app_switcher/app_switcher.c
+++ b/src/app_switcher/app_switcher.c
@@ -353,6 +353,16 @@ static gboolean key_pressed(GtkEventControllerKey *controller, guint keyval,
         return true;
     }
 
+    if (keyval == GDK_KEY_asciitilde && is_super_shift) {
+        select_prev_instance(self);
+        return true;
+    }
+
+    if (keyval == GDK_KEY_grave && (state & GDK_SUPER_MASK)) {
+        select_next_instance(self);
+        return true;
+    }
+
     if (keyval == GDK_KEY_G && is_super_shift) {
         select_prev_instance(self);
         return true;


### PR DESCRIPTION
Use '`' and '~' to move between instances of an app within the app-switcher.

This aligns closer to Gnome's default keymap