### PR TITLE
panel: use widget size request over window default size

### DIFF
--- a/src/panel/panel.c
+++ b/src/panel/panel.c
@@ -119,7 +119,7 @@ static void panel_init_layout(Panel *self) {
     gtk_layer_set_anchor(GTK_WINDOW(self->win), 1, 1);
     gtk_layer_set_anchor(GTK_WINDOW(self->win), 2, 1);
     gtk_layer_set_anchor(GTK_WINDOW(self->win), 3, 0);
-    gtk_window_set_default_size(GTK_WINDOW(self->win), -1, 30);
+    gtk_widget_set_size_request(GTK_WIDGET(self->win), -1, 30);
 
     self->container = GTK_CENTER_BOX(gtk_center_box_new());
     gtk_widget_set_name(GTK_WIDGET(self->container), "panel");


### PR DESCRIPTION
A change in libadwaita 1.6 (7a705c79) makes our old code spawn a huge panel. Adjust ourselves to override libadwaita's default 360x200 size and make the panel reasonable again.

Tested to still work on libadwaita 1.5, too.