### PR TITLE
sni,dconf: enable and disable tray-icons

### DIFF
--- a/data/org.ldelossa.way-shell.gschema.xml
+++ b/data/org.ldelossa.way-shell.gschema.xml
@@ -162,6 +162,19 @@
             Way-Shell must be restarted for changes to take effect.
             </description>
         </key>
+        <key name="enable-tray-icons" type="b">
+            <default>true</default>
+            <summary>Whether tray icons and their menus should be displayed</summary>
+            <description>
+			Way-Shell can display tray icons for applications which present them.
+
+			This is an experimental feature which may cause some issues.
+			Therefore, if issues are encountered you can disable them with this
+			flag.
+
+            Way-Shell must be restarted for changes to take effect.
+            </description>
+        </key>
     </schema>
 
 </schemalist>

--- a/src/panel/panel.c
+++ b/src/panel/panel.c
@@ -4,6 +4,7 @@
 #include <gdk/wayland/gdkwayland.h>
 #include <gtk4-layer-shell/gtk4-layer-shell.h>
 
+#include "../../src/services/status_notifier_service/status_notifier_service.h"
 #include "../activities/activities.h"
 #include "./indicator_bar/indicator_bar.h"
 #include "./panel_status_bar/panel_status_bar.h"
@@ -67,7 +68,7 @@ static void panel_dispose(GObject *gobject) {
     g_object_unref(self->ws_bar);
     g_object_unref(self->monitor);
     g_object_unref(self->clock);
-	g_object_unref(self->indicator_bar);
+    g_object_unref(self->indicator_bar);
 
     g_free(self->monitor_desc);
 
@@ -109,6 +110,15 @@ static void panel_init_status_bar(Panel *self) {
 }
 
 static void panel_init_indicator_bar(Panel *self) {
+    // check if StatusNotifierService is available
+    StatusNotifierService *s = status_notifier_service_get_global();
+    if (!s) {
+        g_debug(
+            "panel.c:panel_init_indicator_bar() StatusNotifierService not "
+            "available, skipping.");
+        return;
+    }
+
     self->indicator_bar = g_object_new(INDICATOR_BAR_TYPE, NULL);
     indicator_bar_set_panel(self->indicator_bar, self);
     gtk_box_prepend(self->right, indicator_bar_get_widget(self->indicator_bar));

--- a/src/services/status_notifier_service/status_notifier_service.c
+++ b/src/services/status_notifier_service/status_notifier_service.c
@@ -567,6 +567,12 @@ GHashTable *status_notifier_service_get_items(StatusNotifierService *self) {
 }
 
 int status_notifier_service_global_init() {
+    GSettings *panel_settings = g_settings_new("org.ldelossa.way-shell.panel");
+
+    gboolean enabled =
+        g_settings_get_boolean(panel_settings, "enable-tray-icons");
+    if (!enabled) return 0;
+
     global = g_object_new(NOTIFICATIONS_SERVICE_TYPE, NULL);
     return 0;
 }


### PR DESCRIPTION
Add a new configration option in dconf at
`org.ldelossa.way-shell.panel.enable-tray-icons` which can be used to disable tray-icon support.